### PR TITLE
support markdown in Read the Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,47 @@
+<div align="center">
+
+# ACCESS Integration Roadmaps Documentation
+
+[Documentation][documentation] • [Getting help](#getting-help) • [Contribute](#contribute)
+
+</div>
+
+---
+
+### Table of Contents
+- [Introduction](#introduction)
+- [Getting help](#getting-help)
+- [Contribute](#contribute)
+
+# Introduction
+
+[ACCESS][ACCESS main page] maintains
+[Integration Roadmaps][integration roadmaps] for
+[Resource Providers][resource providers] on a [Read the Docs][read the docs]
+hosted website found [here][documentation].
+
+# Getting help
+
++ Join us on [Slack][ACCESS slack] in the
+[wg-integration-roadmaps][wg-integration-roadmaps] channel; it's active and
+friendly!
+    + Unable to view [Slack][ACCESS slack]? Request access through the
+    [ACCESS ticketing system][ACCESS rt].
+
++ Search [ACCESS integration roadmaps issues tracker](https://github.com/access-ci-org/Integration_Roadmaps/issues/)
+in case your issue was already reported.
+
+# Contribute
+
+TODO create contribute guidlines doc and link here
+
+We welcome contributions of any kind!
+
+[documentation]: https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/
+[ACCESS main page]: https://access-ci.org/
+[ACCESS rt]: https://tickets.access-ci.org/
+[ACCESS slack]: https://access-ci.slack.com
+[integration roadmaps]: https://operations.access-ci.org/pub/integration_roadmaps
+[read the docs]: https://docs.readthedocs.io/en/stable/
+[resource providers]: https://allocations.access-ci.org/resource-providers
+[wg-integration-roadmaps]: https://app.slack.com/client/T03EW8N9B6Y/C03JSSLABUY

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@ version = '0.1.0'
 # -- General configuration
 
 extensions = [
+    'myst_parser',
     'sphinx.ext.duration',
     'sphinx.ext.doctest',
     'sphinx.ext.autodoc',


### PR DESCRIPTION
- add [markdown parser](https://myst-parser.readthedocs.io/en/latest/intro.html) as recommended by [Read the Docs](https://docs.readthedocs.io/en/stable/intro/getting-started-with-sphinx.html#using-markdown-with-sphinx)
- add [docs/README.md](https://github.com/access-ci-org/Integration_Roadmaps/compare/main...mollycule/support-markdown-via-MyST#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938) that explains Read the Docs process