### PR TITLE
Point link targets to local page instead of Google Doc

### DIFF
--- a/docs/source/cloud/ACCESS_Allocated_Production_Cloud_v2_-_Integration_Roadmap_Description.md
+++ b/docs/source/cloud/ACCESS_Allocated_Production_Cloud_v2_-_Integration_Roadmap_Description.md
@@ -42,41 +42,41 @@ Please track RP integration progress in [*this spreadsheet*](https://docs.google
 
 ## Required Tasks
 
-1.  [*ACCESS Allocated Resource Integration Coordination v1*](https://docs.google.com/document/d/1BRxGZ1c41Cexeck-th4ph3jJgqfJ7exs7glwTZQeDMg/edit?usp=share_link) (NEW)
+1.  [*ACCESS Allocated Resource Integration Coordination v1*](../tasks/ACCESS_Allocated_Resource_Integration_Coordination_v1.md) (NEW)
 
-2.  [*Infrastructure Description v2*](https://docs.google.com/document/d/17vqEoF5lM_eZwBCzkjGwcqkMCiKAOpmfCJWJTGsE42k/edit?usp=share_link)
+2.  [*Infrastructure Description v2*](../tasks/Infrastructure_Description_v2.md)
 
-3.  [*Cybersecurity Requirements for RPs v1*](https://docs.google.com/document/d/1LrfJcgixn-sDuIxZOk47ddoZpCYgwabhWAZYoKOB2TI/edit?usp=share_link)
+3.  [*Cybersecurity Requirements for RPs v1*](../tasks/Cybersecurity_Requirements_for_RPs_v1.md)
 
-4.  [*Data and Network Integration v1*](https://docs.google.com/document/d/1IMOFizZUiXF1PcBR9qXKgQdNUQsVnio8AqcZ3mT74zc/edit?usp=share_link)
+4.  [*Data and Network Integration v1*](../tasks/Data_and_Network_Integration.md)
 
-5.  [*ACCESS Allocation Policies v1*](https://docs.google.com/document/d/1_tdPDLq2FVg6nWUTYAI2Z-LbnlNGdSG3TKAh0d0zZ1I/edit?usp=share_link)
+5.  [*ACCESS Allocation Policies v1*](../tasks/ACCESS_Allocation_Policies_v1.md)
 
-6.  [*Knowledge Base v1*](https://docs.google.com/document/d/1kyhV84JyeL5AdLsqKkdyyeGw6jOuQMZOSCSKNMnfpM8/edit?usp=share_link)
+6.  [*Knowledge Base v1*](../tasks/Knowledge_Base_v1.md)
 
-7.  [*RP Forum Participation v1*](https://docs.google.com/document/d/1azoPUgl7NhY0WyxQsIWOW77Lp_lOqiEiukWHiizMbvI/edit?usp=share_link)
+7.  [*RP Forum Participation v1*](../tasks/Resource_Provider_Forum_Participation_v1.md)
 
-8.  [*Cybersecurity Governance Council Participation v1*](https://docs.google.com/document/d/1hHdN7bISae4caa6lryA5ps2b16uOY7QyEzYsVFYCs8c/edit?usp=share_link)
+8.  [*Cybersecurity Governance Council Participation v1*](../tasks/Cybersecurity_Governance_Council_Participation_v1.md)
 
-9.  [*Resource Metrics Data Availability Assessment v1*](https://docs.google.com/document/d/12MNK2VggHD3JoySK4SgguHARMWJyc91EV2T1vY6Rf_8/edit?usp=share_link)
+9.  [*Resource Metrics Data Availability Assessment v1*](../tasks/Resource_Metrics_Data_Availability_Assessment_v1.md)
 
-10. [*Incident Response and Coordination v1*](https://docs.google.com/document/d/1QVSZEt2GDdlhA-Sogl0YBrGGSaFvZFQPiBCWAvT3PbU/edit?usp=share_link)
+10. [*Incident Response and Coordination v1*](../tasks/Incident_Response_and_Coordination_v1.md)
 
-11. [*Ticket Handling v2*](https://docs.google.com/document/d/12Hl7GqqsAmA5cbmwJRHnb6fONVB1Ywhhf5E6yI0V8d0/edit?usp=share_link)
+11. [*Ticket Handling v2*](../tasks/Ticket_Handling_v2.md)
 
-12. [*Operational Status Communications v1*](https://docs.google.com/document/d/13Rc1fHQydSqfqYdIaFKKIbapenktOKSTxmgGqLpZ-uw/edit?usp=share_link)
+12. [*Operational Status Communications v1*](../tasks/Operational_Status_Communications_v1.md)
 
-13. [*AMIE and Usage Reporting v1*](https://docs.google.com/document/d/1efCqnqVjHfGfzWSKq8kclB7FGfcq__1HhqbvnF0SeSs/edit?usp=share_link)
+13. [*AMIE and Usage Reporting v1*](../tasks/AMIE_and_Usage_Reporting_v1.md)
 
-14. [*Performance Data reporting v1*](https://docs.google.com/document/d/1Tu3Z-3A-pUDmxs5iU1dtfBaReNSB7UkPLzWTErzST7c/edit?usp=share_link)
+14. [*Performance Data reporting v1*](../tasks/Performance_Data_Reporting_v1.md)
 
 ## Optional Tasks
 
-1.  [*ACCESS DNS Entries v1*](https://docs.google.com/document/d/1NhhdiJGZngdpqOMEQrssZXSnDmASQXeQp9ttJPwdQOs/edit?usp=share_link) (NEW)
+1.  [*ACCESS DNS Entries v1*](../tasks/ACCESS_DNS_Records_v1.md) (NEW)
 
-2.  [*Local Service ACCESS IAM Integration v1*](https://docs.google.com/document/d/18GuqHLCj4oxtxt5bsqP_ICw5vMvXM0LQWqc_nLNO8MM/edit?usp=share_link) (NEW)
+2.  [*Local Service ACCESS IAM Integration v1*](../tasks/Local_Services_ACCESS_IAM_Integration_v1.md) (NEW)
 
-3.  [*Request RP or Site Staff Allocation v1*](https://docs.google.com/document/d/1GaHU-7cA3bOFwMvwh3s-Ic9535ncfW741HGnxKFCIOc/edit?usp=share_link)
+3.  [*Request RP or Site Staff Allocation v1*](../tasks/Request_RP_or_Site_Staff_Allocation_v1.md)
 
 ## Document Management
 

--- a/docs/source/compute/ACCESS_Allocated_Production_Compute_v2_-_Integration_Roadmap_Description.md
+++ b/docs/source/compute/ACCESS_Allocated_Production_Compute_v2_-_Integration_Roadmap_Description.md
@@ -42,47 +42,47 @@ Please track RP integration progress in [*this spreadsheet*](https://docs.google
 
 ## Required Tasks
 
-1.  [*ACCESS Allocated Resource Integration Coordination v1*](https://docs.google.com/document/d/1BRxGZ1c41Cexeck-th4ph3jJgqfJ7exs7glwTZQeDMg/edit?usp=share_link) (NEW)
+1.  [*ACCESS Allocated Resource Integration Coordination v1*](../tasks/ACCESS_Allocated_Resource_Integration_Coordination_v1.md) (NEW)
 
-2.  [*Infrastructure Description v2*](https://docs.google.com/document/d/17vqEoF5lM_eZwBCzkjGwcqkMCiKAOpmfCJWJTGsE42k/edit?usp=share_link)
+2.  [*Infrastructure Description v2*](../tasks/Infrastructure_Description_v2.md)
 
-3.  [*Cybersecurity Requirements for RPs v1*](https://docs.google.com/document/d/1LrfJcgixn-sDuIxZOk47ddoZpCYgwabhWAZYoKOB2TI/edit?usp=share_link)
+3.  [*Cybersecurity Requirements for RPs v1*](../tasks/Cybersecurity_Requirements_for_RPs_v1.md)
 
-4.  [*Data and Network Integration v1*](https://docs.google.com/document/d/1IMOFizZUiXF1PcBR9qXKgQdNUQsVnio8AqcZ3mT74zc/edit?usp=share_link)
+4.  [*Data and Network Integration v1*](../tasks/Data_and_Network_Integration.md)
 
-5.  [*ACCESS Allocation Policies v1*](https://docs.google.com/document/d/1_tdPDLq2FVg6nWUTYAI2Z-LbnlNGdSG3TKAh0d0zZ1I/edit?usp=share_link)
+5.  [*ACCESS Allocation Policies v1*](../tasks/ACCESS_Allocation_Policies_v1.md)
 
-6.  [*Knowledge Base v1*](https://docs.google.com/document/d/1kyhV84JyeL5AdLsqKkdyyeGw6jOuQMZOSCSKNMnfpM8/edit?usp=share_link)
+6.  [*Knowledge Base v1*](../tasks/Knowledge_Base_v1.md)
 
-7.  [*Resource Provider Forum Participation v1*](https://docs.google.com/document/d/1azoPUgl7NhY0WyxQsIWOW77Lp_lOqiEiukWHiizMbvI/edit?usp=share_link)
+7.  [*Resource Provider Forum Participation v1*](../tasks/Resource_Provider_Forum_Participation_v1.md)
 
-8.  [*Cybersecurity Governance Council Participation v1*](https://docs.google.com/document/d/1hHdN7bISae4caa6lryA5ps2b16uOY7QyEzYsVFYCs8c/edit?usp=share_link)
+8.  [*Cybersecurity Governance Council Participation v1*](../tasks/Cybersecurity_Governance_Council_Participation_v1.md)
 
-9.  [*Resource Metrics Data Availability Assessment v1*](https://docs.google.com/document/d/12MNK2VggHD3JoySK4SgguHARMWJyc91EV2T1vY6Rf_8/edit?usp=share_link)
+9.  [*Resource Metrics Data Availability Assessment v1*](../tasks/Resource_Metrics_Data_Availability_Assessment_v1.md)
 
-10. [*Deploy Globus Endpoint v1*](https://docs.google.com/document/d/1XM7WflubcukUmTojdm7T_1JH4cUqKfmV6lYjTN-9FTo/edit?usp=share_link)
+10. [*Deploy Globus Endpoint v1*](../tasks/Deploy_Globus_Endpoint_v1.md)
 
-11. [*Publish Dynamic Resource Information v2*](https://docs.google.com/document/d/1x0g28vmx1w58JstBWBMQojicdRdYPdE5lX2Z81Y2CFg/edit?usp=share_link)
+11. [*Publish Dynamic Resource Information v2*](../tasks/Publish_Dynamic_Resource_Information_v2.md)
 
-12. [*Incident Response and Coordination v1*](https://docs.google.com/document/d/1QVSZEt2GDdlhA-Sogl0YBrGGSaFvZFQPiBCWAvT3PbU/edit?usp=share_link)
+12. [*Incident Response and Coordination v1*](../tasks/Incident_Response_and_Coordination_v1.md)
 
-13. [*Ticket Handling v2*](https://docs.google.com/document/d/12Hl7GqqsAmA5cbmwJRHnb6fONVB1Ywhhf5E6yI0V8d0/edit?usp=share_link)
+13. [*Ticket Handling v2*](../tasks/Ticket_Handling_v2.md)
 
-14. [*Operational Status Communications v1*](https://docs.google.com/document/d/13Rc1fHQydSqfqYdIaFKKIbapenktOKSTxmgGqLpZ-uw/edit?usp=share_link)
+14. [*Operational Status Communications v1*](../tasks/Operational_Status_Communications_v1.md)
 
-15. [*AMIE and Usage Reporting v1*](https://docs.google.com/document/d/1efCqnqVjHfGfzWSKq8kclB7FGfcq__1HhqbvnF0SeSs/edit?usp=share_link)
+15. [*AMIE and Usage Reporting v1*](../tasks/AMIE_and_Usage_Reporting_v1.md)
 
-16. [*Performance Data reporting v1*](https://docs.google.com/document/d/1Tu3Z-3A-pUDmxs5iU1dtfBaReNSB7UkPLzWTErzST7c/edit?usp=share_link)
+16. [*Performance Data reporting v1*](../tasks/Performance_Data_Reporting_v1.md)
 
 ## Optional Tasks
 
-1.  [*ACCESS DNS Entries v1*](https://docs.google.com/document/d/1NhhdiJGZngdpqOMEQrssZXSnDmASQXeQp9ttJPwdQOs/edit?usp=share_link) (NEW)
+1.  [*ACCESS DNS Entries v1*](../tasks/ACCESS_DNS_Records_v1.md) (NEW)
 
-2.  [*Local Service ACCESS IAM Integration v1*](https://docs.google.com/document/d/1LPjLip2snJBK_mHIOgstlTo3Fi2nYBT1A8avklTRlo0/edit?usp=share_link) (NEW)
+2.  [*Local Service ACCESS IAM Integration v1*](../tasks/Local_Services_ACCESS_IAM_Integration_v1.md) (NEW)
 
-3.  [*ACCESS OnDemand Portal Integration v1*](https://docs.google.com/document/d/1H3NWzS1uBCpcKZCMc7-omFsvVb1jG8AkFxN2Xju6xS8/edit?usp=share_link) (NEW)
+3.  [*ACCESS OnDemand Portal Integration v1*](../tasks/ACCESS_OnDemand_Portal_Integration_v1.md) (NEW)
 
-4.  [*Request RP or Site Staff Allocation v1*](https://docs.google.com/document/d/1GaHU-7cA3bOFwMvwh3s-Ic9535ncfW741HGnxKFCIOc/edit?usp=share_link)
+4.  [*Request RP or Site Staff Allocation v1*](../tasks/Request_RP_or_Site_Staff_Allocation_v1.md)
 
 ## Document Management
 

--- a/docs/source/gateway/ACCESS_Integrated_Science_Gateway_v1_-_Integration_Roadmap_Description.md
+++ b/docs/source/gateway/ACCESS_Integrated_Science_Gateway_v1_-_Integration_Roadmap_Description.md
@@ -34,19 +34,19 @@ Operators must perform the Required Tasks below and may perform the Optional Tas
 
 ## Required Tasks
 
-1.  [*ACCESS Science Gateway Integration Coordination v1*](https://docs.google.com/document/d/14Zp9E1QGwztSv1G6i4ClR0QP0t2HMhOsjUcg0nuimes/)
+1.  [*ACCESS Science Gateway Integration Coordination v1*](../tasks/ACCESS_Science_Gateway_Integration_Coordination_v1.md)
 
-2.  [*Science Gateway Description v1*](https://docs.google.com/document/d/10shxQ6PallP6EIzFyL8_08cbKzzDvcqg_gVS6-Iv4lQ/)
+2.  [*Science Gateway Description v1*](../tasks/Science_Gateway_Description_v1.md)
 
-3.  [*Request Science Gateway Allocation v1*](https://docs.google.com/document/d/11kHQ17OjvRt8ZoRdriS1bn7-gbxCdCHNWZ9-gD60axg/)
+3.  [*Request Science Gateway Allocation v1*](../tasks/Request_Science_Gateway_Allocation_v1.md)
 
-4.  [*Request Science Gateway Resources v1*](https://docs.google.com/document/d/1hAEUJstG0y2bIndOuwaWe1uUa2CSfuLS0IWVEBRlNDg/)
+4.  [*Request Science Gateway Resources v1*](../tasks/Request_Science_Gateway_Resources_v1.md)
 
-5.  [*ACCESS Affinity Groups and Science Gateways v1*](https://docs.google.com/document/d/18lzzLrJRHZbLiOqLRveURxMW8Puu_K-NGC0oqm1rA2k/)
+5.  [*ACCESS Affinity Groups and Science Gateways v1*](../tasks/ACCESS_Affinity_Groups_and_Science_Gateways_v1.md)
 
-6.  [*Request Science Gateway Community Accounts v1*](https://docs.google.com/document/d/1UbY_gqOFPTf_ncVAOqHMMIgN5Q5dq2CenbjQ1mGWRHE/)
+6.  [*Request Science Gateway Community Accounts v1*](../tasks/Request_Science_Gateway_Community_Accounts_v1.md)
 
-7.  [*Science Gateway Usage Reporting v1*](https://docs.google.com/document/d/1uHomPNJ20jM2xatgxWSouTTo40iARR4SYHKQiYU6kB4/)
+7.  [*Science Gateway Usage Reporting v1*](../tasks/Science_Gateway_Usage_Reporting_v1.md)
 
 ## Optional Tasks
 

--- a/docs/source/onlineservice/ACCESS_Production_Online_Service_v2_-_Integration_Roadmap_Description.md
+++ b/docs/source/onlineservice/ACCESS_Production_Online_Service_v2_-_Integration_Roadmap_Description.md
@@ -28,29 +28,29 @@ See related [*Roadmap Task Timeline*](https://docs.google.com/presentation/d/1GI
 
 ## Required Tasks
 
-1.  [*Infrastructure Description v2*](https://docs.google.com/document/d/17vqEoF5lM_eZwBCzkjGwcqkMCiKAOpmfCJWJTGsE42k/edit?usp=share_link)
+1.  [*Infrastructure Description v2*](../tasks/Infrastructure_Description_v2.md)
 
-2.  [*Cybersecurity Requirements for ACCESS Services v1*](https://docs.google.com/document/d/1mBPL4Y6bzn7jSZNMAJ05vhHbue_xVx5QFVOEG3CNV3Q/)
+2.  [*Cybersecurity Requirements for ACCESS Services v1*](../tasks/Cybersecurity_Requirements_for_ACCESS_Services_v1.md)
 
-3.  [*Cybersecurity Governance Council Participation v1*](https://docs.google.com/document/d/1hHdN7bISae4caa6lryA5ps2b16uOY7QyEzYsVFYCs8c/edit?usp=share_link)
+3.  [*Cybersecurity Governance Council Participation v1*](../tasks/Cybersecurity_Governance_Council_Participation_v1.md)
 
-4.  [*Online Service Documentation v1*](https://docs.google.com/document/d/1lKVw4sPI2HiAYeM6EgtKUB5s9RHJGRMeHKqF6OKQyf4/)
+4.  [*Online Service Documentation v1*](../tasks/Online_Service_Documentation_v1.md)
 
-5.  [*Incident Response and Coordination v1*](https://docs.google.com/document/d/1QVSZEt2GDdlhA-Sogl0YBrGGSaFvZFQPiBCWAvT3PbU/edit?usp=share_link)
+5.  [*Incident Response and Coordination v1*](../tasks/Incident_Response_and_Coordination_v1.md)
 
-6.  [*Ticket Handling v2*](https://docs.google.com/document/d/12Hl7GqqsAmA5cbmwJRHnb6fONVB1Ywhhf5E6yI0V8d0/edit?usp=share_link)
+6.  [*Ticket Handling v2*](../tasks/Ticket_Handling_v2.md)
 
-7.  [*Operational Status Communications v1*](https://docs.google.com/document/d/13Rc1fHQydSqfqYdIaFKKIbapenktOKSTxmgGqLpZ-uw/edit?usp=share_link)
+7.  [*Operational Status Communications v1*](../tasks/Operational_Status_Communications_v1.md)
 
 ## Optional Tasks
 
-1.  [*ACCESS DNS Records v1*](https://docs.google.com/document/d/1NhhdiJGZngdpqOMEQrssZXSnDmASQXeQp9ttJPwdQOs/edit?usp=share_link)
+1.  [*ACCESS DNS Records v1*](../tasks/ACCESS_DNS_Records_v1.md)
 
-2.  [*Service ACCESS IAM Integration v1*](https://docs.google.com/document/d/1LPjLip2snJBK_mHIOgstlTo3Fi2nYBT1A8avklTRlo0/edit?usp=share_link)
+2.  [*Service ACCESS IAM Integration v1*](../tasks/Local_Services_ACCESS_IAM_Integration_v1.md)
 
-3.  [*Request RP or Site Staff Allocation v1*](https://docs.google.com/document/d/1GaHU-7cA3bOFwMvwh3s-Ic9535ncfW741HGnxKFCIOc/edit?usp=share_link)
+3.  [*Request RP or Site Staff Allocation v1*](../tasks/Request_RP_or_Site_Staff_Allocation_v1.md)
 
-4.  [*Performance Data Reporting v1*](https://docs.google.com/document/d/1Tu3Z-3A-pUDmxs5iU1dtfBaReNSB7UkPLzWTErzST7c/edit?usp=share_link)
+4.  [*Performance Data Reporting v1*](../tasks/Performance_Data_Reporting_v1.md)
 
 ## Document Management
 

--- a/docs/source/storage/ACCESS_Allocated_Production_Storage_v2_-_Integration_Roadmap_Description.md
+++ b/docs/source/storage/ACCESS_Allocated_Production_Storage_v2_-_Integration_Roadmap_Description.md
@@ -42,43 +42,43 @@ Please track RP integration progress in [*this spreadsheet*](https://docs.google
 
 ## Required Tasks
 
-1.  [*ACCESS Allocated Resource Integration Coordination v1*](https://docs.google.com/document/d/1BRxGZ1c41Cexeck-th4ph3jJgqfJ7exs7glwTZQeDMg/edit?usp=share_link) (NEW)
+1.  [*ACCESS Allocated Resource Integration Coordination v1*](../tasks/ACCESS_Allocated_Resource_Integration_Coordination_v1.md) (NEW)
 
-2.  [*Infrastructure Description v2*](https://docs.google.com/document/d/17vqEoF5lM_eZwBCzkjGwcqkMCiKAOpmfCJWJTGsE42k/edit?usp=share_link)
+2.  [*Infrastructure Description v2*](../tasks/Infrastructure_Description_v2.md)
 
-3.  [*Cybersecurity Requirements for RPs v1*](https://docs.google.com/document/d/1LrfJcgixn-sDuIxZOk47ddoZpCYgwabhWAZYoKOB2TI/edit?usp=share_link)
+3.  [*Cybersecurity Requirements for RPs v1*](../tasks/Cybersecurity_Requirements_for_RPs_v1.md)
 
-4.  [*Data and Network Integration v1*](https://docs.google.com/document/d/1IMOFizZUiXF1PcBR9qXKgQdNUQsVnio8AqcZ3mT74zc/edit?usp=share_link)
+4.  [*Data and Network Integration v1*](../tasks/Data_and_Network_Integration.md)
 
-5.  [*ACCESS Allocation Policies v1*](https://docs.google.com/document/d/1_tdPDLq2FVg6nWUTYAI2Z-LbnlNGdSG3TKAh0d0zZ1I/edit?usp=share_link)
+5.  [*ACCESS Allocation Policies v1*](../tasks/ACCESS_Allocation_Policies_v1.md)
 
-6.  [*Knowledge Base v1*](https://docs.google.com/document/d/1kyhV84JyeL5AdLsqKkdyyeGw6jOuQMZOSCSKNMnfpM8/edit?usp=share_link)
+6.  [*Knowledge Base v1*](../tasks/Knowledge_Base_v1.md)
 
-7.  [*RP Forum Participation v1*](https://docs.google.com/document/d/1azoPUgl7NhY0WyxQsIWOW77Lp_lOqiEiukWHiizMbvI/edit?usp=share_link)
+7.  [*RP Forum Participation v1*](../tasks/Resource_Provider_Forum_Participation_v1.md)
 
-8.  [*Cybersecurity Governance Council Participation v1*](https://docs.google.com/document/d/1hHdN7bISae4caa6lryA5ps2b16uOY7QyEzYsVFYCs8c/edit?usp=share_link)
+8.  [*Cybersecurity Governance Council Participation v1*](../tasks/Cybersecurity_Governance_Council_Participation_v1.md)
 
-9.  [*Resource Metrics Data Availability Assessment v1*](https://docs.google.com/document/d/12MNK2VggHD3JoySK4SgguHARMWJyc91EV2T1vY6Rf_8/edit?usp=share_link)
+9.  [*Resource Metrics Data Availability Assessment v1*](../tasks/Resource_Metrics_Data_Availability_Assessment_v1.md)
 
-10. [*Deploy Globus Endpoint v1*](https://docs.google.com/document/d/1XM7WflubcukUmTojdm7T_1JH4cUqKfmV6lYjTN-9FTo/edit?usp=share_link)
+10. [*Deploy Globus Endpoint v1*](../tasks/Deploy_Globus_Endpoint_v1.md)
 
-11. [*Incident Response and Coordination v1*](https://docs.google.com/document/d/1QVSZEt2GDdlhA-Sogl0YBrGGSaFvZFQPiBCWAvT3PbU/edit?usp=share_link)
+11. [*Incident Response and Coordination v1*](../tasks/Incident_Response_and_Coordination_v1.md)
 
-12. [*Ticket Handling v2*](https://docs.google.com/document/d/12Hl7GqqsAmA5cbmwJRHnb6fONVB1Ywhhf5E6yI0V8d0/edit?usp=share_link)
+12. [*Ticket Handling v2*](../tasks/Ticket_Handling_v2.md)
 
-13. [*Operational Status Communications v1*](https://docs.google.com/document/d/13Rc1fHQydSqfqYdIaFKKIbapenktOKSTxmgGqLpZ-uw/edit?usp=share_link)
+13. [*Operational Status Communications v1*](../tasks/Operational_Status_Communications_v1.md)
 
-14. [*AMIE and Usage Reporting v1*](https://docs.google.com/document/d/1efCqnqVjHfGfzWSKq8kclB7FGfcq__1HhqbvnF0SeSs/edit?usp=share_link)
+14. [*AMIE and Usage Reporting v1*](../tasks/AMIE_and_Usage_Reporting_v1.md)
 
-15. [*Performance Data reporting v1*](https://docs.google.com/document/d/1Tu3Z-3A-pUDmxs5iU1dtfBaReNSB7UkPLzWTErzST7c/edit?usp=share_link)
+15. [*Performance Data reporting v1*](../tasks/Performance_Data_Reporting_v1.md)
 
 ## Optional Tasks
 
-1.  [*ACCESS DNS Entries v1*](https://docs.google.com/document/d/1NhhdiJGZngdpqOMEQrssZXSnDmASQXeQp9ttJPwdQOs/edit?usp=share_link) (NEW)
+1.  [*ACCESS DNS Entries v1*](../tasks/ACCESS_DNS_Records_v1.md) (NEW)
 
-2.  [*Local Service ACCESS IAM Integration v1*](https://docs.google.com/document/d/18GuqHLCj4oxtxt5bsqP_ICw5vMvXM0LQWqc_nLNO8MM/edit?usp=share_link) (NEW)
+2.  [*Local Service ACCESS IAM Integration v1*](../tasks/Local_Services_ACCESS_IAM_Integration_v1.md) (NEW)
 
-3.  [*Request RP or Site Staff Allocation v1*](https://docs.google.com/document/d/1GaHU-7cA3bOFwMvwh3s-Ic9535ncfW741HGnxKFCIOc/edit?usp=share_link)
+3.  [*Request RP or Site Staff Allocation v1*](../tasks/Request_RP_or_Site_Staff_Allocation_v1.md)
 
 ## Document Management
 

--- a/docs/source/tasks/ACCESS_Allocation_Policies_v1.md
+++ b/docs/source/tasks/ACCESS_Allocation_Policies_v1.md
@@ -23,7 +23,7 @@ For assistance with this task see the *Support Information* section in the *Inte
 
 The Resource Provider must first identify an Allocations contact for each resource RP makes available for allocations via ACCESS. This contact(s) will work with Allocations and/or other ACCESS tracks to provide documentation/user guides for each of their resources. The contact will be the main liaison for Allocations as well as user community and review panels. RP contact will need to provide available resource information, review proposals of smaller Allocation requests. Contact will need to provide resource information for RDR of resource(s) and keep RDR updated for the life of resource(s). Email [*help@xsede.org*](mailto:help@xsede.org) with subject “Track 1 Roadmaps - allocations contact” or email [*hackwort@psc.edu*](mailto:hackwort@psc.edu) to provide contact details.  
   
-Instructions for entering resource information are specified in a later roadmap step: [*Infrastructure Description*](https://docs.google.com/document/d/1RJCEFLL1vjSOo-plBRK67qwTePXahbvsuZVoGOlYTFg/)
+Instructions for entering resource information are specified in a later roadmap step: [*Infrastructure Description*](Infrastructure_Description_v2.md)
 
 ## Document Management
 

--- a/docs/source/tasks/CONECTnet_Integration_v1.md
+++ b/docs/source/tasks/CONECTnet_Integration_v1.md
@@ -15,7 +15,7 @@ CONECTnet participants are encouraged to take advantage of network measurement a
 
 ## Prerequisite tasks
 
-1.  [*Data and Network Integration*](https://docs.google.com/document/d/1IMOFizZUiXF1PcBR9qXKgQdNUQsVnio8AqcZ3mT74zc/)
+1.  [*Data and Network Integration*](Data_and_Network_Integration.md)
 
 ## Support Information
 

--- a/docs/source/tasks/Cybersecurity_Governance_Council_Participation__v1.md
+++ b/docs/source/tasks/Cybersecurity_Governance_Council_Participation__v1.md
@@ -19,7 +19,7 @@ Bi-weekly meetings transitioning to monthly meetings lasting 30min-1hour.
 
 ## Prerequisite tasks
 
-Familiarity with [*Cybersecurity Requirements for RPs v1*](https://docs.google.com/document/d/1LrfJcgixn-sDuIxZOk47ddoZpCYgwabhWAZYoKOB2TI/edit#)
+Familiarity with [*Cybersecurity Requirements for RPs v1*](Cybersecurity_Requirements_for_RPs_v1.md)
 
 ## Support Information
 

--- a/docs/source/tasks/Cybersecurity_Governance_Council_Participation_v1.md
+++ b/docs/source/tasks/Cybersecurity_Governance_Council_Participation_v1.md
@@ -19,7 +19,7 @@ Bi-weekly meetings transitioning to monthly meetings lasting 30/min to 1/hour.
 
 ## Prerequisite tasks
 
-- [*Cybersecurity Requirements for RPs v1*](https://docs.google.com/document/d/1LrfJcgixn-sDuIxZOk47ddoZpCYgwabhWAZYoKOB2TI/edit#)
+- [*Cybersecurity Requirements for RPs v1*](Cybersecurity_Requirements_for_RPs_v1.md)
 
 ## Support Information
 

--- a/docs/source/tasks/Data_and_Network_Integration.md
+++ b/docs/source/tasks/Data_and_Network_Integration.md
@@ -89,7 +89,7 @@ The ACCESS ecosystem offers a Layer3 VPN (L3VPN) provisioned on Internet2 (CONEC
 
 The supported file transfer applications for ACCESS are currently scp, sftp, rsync, and Globus. scp, sftp, and rsync are commonly used file transfer applications. Other than verifying that the servers are running (system administrators) and accessible (network engineers for site firewalls; system administrators for IPtables, firewalld, etc.), these applications likely will not require special configuration and management for use by ACCESS participants.
 
-Globus requires specific system, application, and (potentially) hardware configuration. Please see the ACCESS CONECT document [**Deploy Globus Endpoint**](https://docs.google.com/document/d/19xv0ahgH8m4pFsu5LabYdOVSaNjmB6Ja1Q7I7cc_dM8/edit?usp=sharing) for detailed guidance.
+Globus requires specific system, application, and (potentially) hardware configuration. Please see the ACCESS CONECT document [**Deploy Globus Endpoint**](Deploy_Globus_Endpoint_v1.md) for detailed guidance.
 
 ## Document Management
 

--- a/docs/source/tasks/Incident_Response_and_Coordination_v1.md
+++ b/docs/source/tasks/Incident_Response_and_Coordination_v1.md
@@ -19,9 +19,9 @@ AIRTG meetings occur weekly and take less than 30 minutes.
 
 ## Prerequisite tasks
 
-- [*Cybersecurity Requirements for RPs v1*](https://docs.google.com/document/d/1LrfJcgixn-sDuIxZOk47ddoZpCYgwabhWAZYoKOB2TI/edit#)
+- [*Cybersecurity Requirements for RPs v1*](Cybersecurity_Requirements_for_RPs_v1.md)
 
-- [*Cybersecurity Governance Council Participation v1*](https://docs.google.com/document/d/1hHdN7bISae4caa6lryA5ps2b16uOY7QyEzYsVFYCs8c/edit#)
+- [*Cybersecurity Governance Council Participation v1*](Cybersecurity_Governance_Council_Participation_v1.md)
 
 ## Support Information
 

--- a/docs/source/tasks/Knowledge_Base_v1.md
+++ b/docs/source/tasks/Knowledge_Base_v1.md
@@ -21,7 +21,7 @@ The following information should be available through CiDeR to ensure that your 
 
 ## Prerequisite tasks
 
-- [*Resource Description V2*](https://docs.google.com/document/d/1khvZ7QiwKoVDJy0lEq429M7a9sQXBXzTfWoYsUafqVc/)
+- [*Resource Description V2*](Infrastructure_Description_v2.md)
 
 ## Support Information
 

--- a/docs/source/tasks/Local_Services_ACCESS_IAM_Integration_v1.md
+++ b/docs/source/tasks/Local_Services_ACCESS_IAM_Integration_v1.md
@@ -13,9 +13,9 @@ This task provides guidance for Resource Providers that want to integrate their 
 
 ## Prerequisite tasks
 
-- [*Cybersecurity Requirements for RPs v1*](https://docs.google.com/document/d/1LrfJcgixn-sDuIxZOk47ddoZpCYgwabhWAZYoKOB2TI/edit#)
+- [*Cybersecurity Requirements for RPs v1*](Cybersecurity_Requirements_for_RPs_v1.md)
 
-- [*Cybersecurity Governance Council Participation v1*](https://docs.google.com/document/d/1hHdN7bISae4caa6lryA5ps2b16uOY7QyEzYsVFYCs8c/edit#)
+- [*Cybersecurity Governance Council Participation v1*](Cybersecurity_Governance_Council_Participation_v1.md)
 
 ## Support Information
 

--- a/docs/source/tasks/Online_Service_Documentation_v1.md
+++ b/docs/source/tasks/Online_Service_Documentation_v1.md
@@ -13,7 +13,7 @@ The purpose of this task is to ensure that the online service operator provides 
 
 ## Prerequisite tasks
 
-- [*Resource Description V2*](https://docs.google.com/document/d/1khvZ7QiwKoVDJy0lEq429M7a9sQXBXzTfWoYsUafqVc/)
+- [*Resource Description V2*](Infrastructure_Description_v2.md)
 
 ## Support Information
 
@@ -33,7 +33,7 @@ Online services may provide documentation through one of the following ACCESS co
 
 - ACCESS Documentation / Knowledge Base - for services used by ACCESS users
 
-  - See the [*Knowledge Base integration task*](https://docs.google.com/document/d/1kyhV84JyeL5AdLsqKkdyyeGw6jOuQMZOSCSKNMnfpM8/edit?usp=share_link)
+  - See the [*Knowledge Base integration task*](Knowledge_Base_v1.md)
 
 - If a separate workspace may be appropriate, contact the ACO to discuss and request it
 
@@ -45,7 +45,7 @@ Online services with their own web sites may publish their documentation through
 
 ### Describing where documentation is
 
-See the [*Infrastructure Description task*](https://docs.google.com/document/d/17vqEoF5lM_eZwBCzkjGwcqkMCiKAOpmfCJWJTGsE42k/edit?usp=share_link) for how to record the documentation URL in the CiDeR online service description.
+See the [*Infrastructure Description task*](Infrastructure_Description_v2.md) for how to record the documentation URL in the CiDeR online service description.
 
 ## Document Management
 

--- a/docs/source/tasks/Operational_Status_Communications_v1.md
+++ b/docs/source/tasks/Operational_Status_Communications_v1.md
@@ -13,7 +13,7 @@ ACCESS resource providers RPs, ACCESS projects (tracks), and online service oper
 
 ## Prerequisite tasks
 
-1.  [*Resource Description V2*](https://docs.google.com/document/d/1khvZ7QiwKoVDJy0lEq429M7a9sQXBXzTfWoYsUafqVc/)
+1.  [*Resource Description V2*](Infrastructure_Description_v2.md)
 
 ## Support Information
 

--- a/docs/source/tasks/Performance_Data_Reporting_v1.md
+++ b/docs/source/tasks/Performance_Data_Reporting_v1.md
@@ -17,7 +17,7 @@ This task involves setting up the data transfer of performance data.
 
 ## Prerequisite tasks
 
-1.  [*Resource Metrics Data Availability Assessment v1*](https://docs.google.com/document/d/12MNK2VggHD3JoySK4SgguHARMWJyc91EV2T1vY6Rf_8/edit#)
+1.  [*Resource Metrics Data Availability Assessment v1*](Resource_Metrics_Data_Availability_Assessment_v1.md)
 
 ## Support Information
 

--- a/docs/source/tasks/Publish_Dynamic_Resource_Information_v2.md
+++ b/docs/source/tasks/Publish_Dynamic_Resource_Information_v2.md
@@ -13,7 +13,7 @@ This task involves installing and running the Information Publishing Framework (
 
 ## Prerequisite tasks
 
-1.  [*Infrastructure Description v2*](https://docs.google.com/document/d/17vqEoF5lM_eZwBCzkjGwcqkMCiKAOpmfCJWJTGsE42k/edit?usp=share_link)
+1.  [*Infrastructure Description v2*](Infrastructure_Description_v2.md)
 
 ## Support Information
 

--- a/docs/source/tasks/Request_Science_Gateway_Allocation_v1.md
+++ b/docs/source/tasks/Request_Science_Gateway_Allocation_v1.md
@@ -9,7 +9,7 @@ Infrastructure Integration Roadmap Task
 
 ## Summary
 
-A science gateway provider needs to have an active allocation for their science gateway. This can be done before or after the [*Science Gateway Description v1*](https://docs.google.com/document/d/10shxQ6PallP6EIzFyL8_08cbKzzDvcqg_gVS6-Iv4lQ/) tasks have been completed.
+A science gateway provider needs to have an active allocation for their science gateway. This can be done before or after the [*Science Gateway Description v1*](Science_Gateway_Description_v1.md) tasks have been completed.
 
 ## Prerequisite tasks
 

--- a/docs/source/tasks/Request_Science_Gateway_Community_Accounts_v1.md
+++ b/docs/source/tasks/Request_Science_Gateway_Community_Accounts_v1.md
@@ -13,7 +13,7 @@ Science gateways use community accounts to provide single accounts for all gatew
 
 ## Prerequisite tasks
 
-1.  The gateway provider must have completed [*Science Gateways Description*](https://docs.google.com/document/d/10shxQ6PallP6EIzFyL8_08cbKzzDvcqg_gVS6-Iv4lQ/)
+1.  The gateway provider must have completed [*Science Gateways Description*](Science_Gateway_Description_v1.md)
 
 ## Support Information
 

--- a/docs/source/tasks/Request_Science_Gateway_Resources_v1.md
+++ b/docs/source/tasks/Request_Science_Gateway_Resources_v1.md
@@ -13,7 +13,7 @@ Science gateway operators request that their awarded allocation credits be excha
 
 ## Prerequisite tasks
 
-1.  The science gateway operator must have an awarded allocation. See the document at [*Request Science Gateway Allocation v1*](https://docs.google.com/document/d/11kHQ17OjvRt8ZoRdriS1bn7-gbxCdCHNWZ9-gD60axg/). Depending on the size of the request, this could take days to weeks to complete.
+1.  The science gateway operator must have an awarded allocation. See the document at [*Request Science Gateway Allocation v1*](Request_Science_Gateway_Allocation_v1.md). Depending on the size of the request, this could take days to weeks to complete.
 
 ## Support Information
 

--- a/docs/source/tasks/Science_Gateway_Usage_Reporting_v1.md
+++ b/docs/source/tasks/Science_Gateway_Usage_Reporting_v1.md
@@ -13,7 +13,7 @@ Science gateways that execute jobs on ACCESS resource provider resources report 
 
 ## Prerequisite tasks
 
-1.  The gateway must have an allocation and a community account. See [*Request Science Gateway Community Accounts v1*](https://docs.google.com/document/d/1UbY_gqOFPTf_ncVAOqHMMIgN5Q5dq2CenbjQ1mGWRHE/).
+1.  The gateway must have an allocation and a community account. See [*Request Science Gateway Community Accounts v1*](Request_Science_Gateway_Community_Accounts_v1.md).
 
 ## Support Information
 

--- a/docs/source/tasks/Ticket_Handling_v1.md
+++ b/docs/source/tasks/Ticket_Handling_v1.md
@@ -15,7 +15,7 @@ ACCESS resource and online service operators will be assigned tickets for issues
 
 ## Prerequisite tasks
 
-1.  [*Infrastructure Description v2*](https://docs.google.com/document/d/17vqEoF5lM_eZwBCzkjGwcqkMCiKAOpmfCJWJTGsE42k/edit?usp=share_link)
+1.  [*Infrastructure Description v2*](Infrastructure_Description_v2.md)
 
 ## Support Information
 

--- a/docs/source/tasks/Ticket_Handling_v2.md
+++ b/docs/source/tasks/Ticket_Handling_v2.md
@@ -15,7 +15,7 @@ ACCESS resource and online service operators will be assigned tickets for issues
 
 ## Prerequisite tasks
 
-1.  [*Infrastructure Description v2*](https://docs.google.com/document/d/17vqEoF5lM_eZwBCzkjGwcqkMCiKAOpmfCJWJTGsE42k/edit?usp=share_link)
+1.  [*Infrastructure Description v2*](Infrastructure_Description_v2.md)
 
 ## Support Information
 


### PR DESCRIPTION
This fixes #5. I built the site locally and verified that the link targets in the output HTML point to local pages (and they work).

There are a few links targeting Google Docs that are not themselves roadmaps and tasks, and we don't have Markdown source for them. I left those links alone for now.