### PR TITLE
Re-create tables in Markdown source

### DIFF
--- a/docs/source/tasks/Deploy_Globus_Endpoint_v1.md
+++ b/docs/source/tasks/Deploy_Globus_Endpoint_v1.md
@@ -27,7 +27,13 @@ The following estimates assume starting from scratch. If you have already deploy
 
 The following assumes you have already acquired DTN servers with appropriate network interface(s) and memory, and network hardware with an appropriate topology for high-performance data transfers. Requirements for these should have been produced by roadmap task 2.1, *Data & Networking integration design*.
 
-[TABLE]
+| Task                                                                                   | Estimated effort/time                          |
+|----------------------------------------------------------------------------------------|------------------------------------------------|
+| Deploy DTN hardware with the required network connectivity                             | 1 person-day effort (1 week start-to-finish)   |
+| Provision local accounts on DTNs                                                       | 2 person-day effort (2 weeks start-to-finish)  |
+| Mount and configure POSIX storage on DTNs                                              | 1 person-day effort (½ week start-to-finish)   |
+| Install and configure Globus Connect Server on DTNs (inc. access policy configuration) | 1 person-day effort (1 week start-to-finish)   |
+| Evaluate and optimize performance                                                      | 1 person-week effort (3 weeks start-to-finish) |
 
 ## Prerequisite tasks
 

--- a/docs/source/tasks/Infrastructure_Description_v2.md
+++ b/docs/source/tasks/Infrastructure_Description_v2.md
@@ -83,13 +83,25 @@ Steps:
 
 - Select Resource Features as follows:
 
-[TABLE]
+| Applicable Resource Type        | Features                                                                                                                                                                                                                                                                           |
+|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Compute, Cloud, Storage         | Select from the following features:<br>- Sensitive data support<br>- Community software areas for users<br>- Visualization support<br>- Advanced reservation support<br>- Discounted preemptible queue support<br>- CONECTnet attached<br>- Internal resource not visible to users |
+| Compute, Cloud, Storage         | If your resource supports science gateways select features starting with “Science Gateway *”.                                                                                                                                                                                      |
+| Online Services                 | Select from the following features:<br>- ACCESS Online Services for users<br>- ACCESS Online Services for resource providers<br>- ACCESS Online Services for developers<br>- ACCESS Online Services for ACCESS projects                                                            |
+| Science Gateway Online Services | This feature designates a registered Online Service as a science gateway:<br>- ACCESS Integrated Science Gateways                                                                                                                                                                  |
 
 - Select a “Resource Type” at the bottom of the screen and “Create Resource”
 
 - For Compute, Cloud, and Storage type resources, enter as much information as possible in this second form and the following **minimum required information**:
 
-[TABLE]
+| Field Name      | Applicable Resource Type | Notes                                                                      |
+|-----------------|--------------------------|----------------------------------------------------------------------------|
+| NodeCount       | Compute, Cloud           | For cloud record the number of controller nodes.                           |
+| CPUCountPerNode | Compute, Cloud           | For heterogeneous clusters use the mean value per node                     |
+| MemoryPerCPUGB  | Compute, Cloud           | For heterogeneous clusters use the mean value per node                     |
+| PeakTeraflops   | Compute                  | Leave blank if unknown                                                     |
+| DiskSizeTB      | Compute                  | For heterogeneous clusters use the mean value per node                     |
+| FileSpaceTB     | Compute, Storage, Cloud  | Total amount of shared storage (network attached and parallel file-system) |
 
 ### Enter Resource Conversion Factors
 


### PR DESCRIPTION
Re-creates the three tables that were replaced with `[TABLE]` during the automated document conversion.

Fixes #12.