### PR TITLE
Add issue template for new integration roadmaps

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-access-integration-roadmap.md
+++ b/.github/ISSUE_TEMPLATE/new-access-integration-roadmap.md
@@ -1,0 +1,26 @@
+---
+name: New ACCESS integration roadmap
+about: For starting work on a new ACCESS integration roadmap
+title: New integration roadmap for <resource type here>
+labels: roadmaps
+assignees: jpnavarro, winona-sc
+
+---
+
+What type of cyberinfrastructure resource is this integration roadmap for?
+<resource-type>
+
+Which current resource(s) will use this roadmap to integrate with ACCESS when it's ready?
+<resource-1>
+<resource-2>
+...
+
+Who will be organizing the work to draft this new integration roadmap?
+<person-1> <email-1>
+<person-2> <email-2>
+...
+
+A member of the ACCESS Operations team will be reaching out to the people above to discuss the plans for the new roadmap. Please suggest at least two times that would be good for this initial meeting.
+<time-zone>
+<date-and-time-1>
+<date-and-time-2>


### PR DESCRIPTION
This issue template will be referenced in documentation and used to initiate the process of creating/proposing a new ACCESS integration roadmap