### PR TITLE
replace Alex Withers with Derek Simmel for Cybersecurity Coordinator

### DIFF
--- a/docs/source/tasks/Cybersecurity_Requirements_for_ACCESS_Services_v1.md
+++ b/docs/source/tasks/Cybersecurity_Requirements_for_ACCESS_Services_v1.md
@@ -35,10 +35,10 @@ For assistance with this task see the *Support Information* section in the *Inte
 
 **Status**: Official
 
-**Official date**: 4/24/2023 \<mm/dd/yyyy\>
+**Official date**: 4/24/2023
 
-**Coordinators**: Alex Withers & Shane Filus, CONECT Cybersecurity Program
+**Coordinators**: Derek Simmel & Shane Filus, CONECT Cybersecurity Program
 
-**Last revised date**: 2/16/2023
+**Last revised date**: 07/13/2023
 
 **Retired date**:

--- a/docs/source/tasks/Cybersecurity_Requirements_for_RPs_v1.md
+++ b/docs/source/tasks/Cybersecurity_Requirements_for_RPs_v1.md
@@ -65,10 +65,10 @@ Requirements for this review are driven by ACCESS community policies, listed bel
 
 **Status**: Official
 
-**Official date**: 4/24/2023 \<mm/dd/yyyy\>
+**Official date**: 4/24/2023
 
-**Coordinators**: Alex Withers & Shane Filus, CONECT Cybersecurity Program
+**Coordinators**: Derek Simmel & Shane Filus, CONECT Cybersecurity Program
 
-**Last revised date**: 2/16/2023
+**Last revised date**: 07/13/2023
 
 **Retired date**:

--- a/docs/source/tasks/Incident_Response_and_Coordination_v1.md
+++ b/docs/source/tasks/Incident_Response_and_Coordination_v1.md
@@ -47,10 +47,10 @@ You will receive a response from ACCESS CONECT Cybersecurity Group indicating th
 
 **Status**: Official
 
-**Official date**: 4/24/2023 \<mm/dd/yyyy\>
+**Official date**: 4/24/2023
 
-**Coordinators**: Alex Withers, CONECT Cybersecurity Program; Shane Filus, CONECT Cybersecurity Program
+**Coordinators**: Derek Simmel & Shane Filus, CONECT Cybersecurity Program
 
-**Last revised date**: 02/16/2023
+**Last revised date**: 07/13/2023
 
-**Retired date**: \<mm/dd/yyyy\> or blank
+**Retired date**:

--- a/docs/source/tasks/Local_Services_ACCESS_IAM_Integration_v1.md
+++ b/docs/source/tasks/Local_Services_ACCESS_IAM_Integration_v1.md
@@ -47,10 +47,10 @@ Related Identity and Access Management (IAM) instructions and documentation:
 
 **Status**: Official
 
-**Official date**: 4/24/2023 \<mm/dd/yyyy\>
+**Official date**: 4/24/2023
 
-**Coordinators**: Alex Withers & Shane Filus, CONECT Cybersecurity Program
+**Coordinators**: Derek Simmel & Shane Filus, CONECT Cybersecurity Program
 
-**Last revised date**: 03/14/2023
+**Last revised date**: 07/13/2023
 
 **Retired date**:


### PR DESCRIPTION
resolves #38

i changed references of Alex Withers to Derek Simmel in accordance with https://access-ci.atlassian.net/wiki/spaces/ACP/pages/17891451/ACCESS+Operations+Cybersecurity+Support