### PR TITLE
order all roadmaps by phases, not required/optional

### DIFF
--- a/docs/source/cloud/ACCESS_Allocated_Production_Cloud_-_Integration_Roadmap_Description.md
+++ b/docs/source/cloud/ACCESS_Allocated_Production_Cloud_-_Integration_Roadmap_Description.md
@@ -40,52 +40,54 @@ Please track RP integration progress in [*this spreadsheet*](https://docs.google
 
 - [*ACCESS RP Roadmaps FAQ*](https://docs.google.com/document/d/1VwYROB7sh4X_Tqvi_4XIkYD-jffBS4UykS6gEJesuQE/)
 
-## Required Tasks
+## Planning phase
 
-1.  [*ACCESS Allocated Resource Integration Coordination v1*](../tasks/ACCESS_Allocated_Resource_Integration_Coordination_v1.md) (NEW)
+1. Coordination: [ACCESS Allocated Resource Integration Coordination v1](../tasks/ACCESS_Allocated_Resource_Integration_Coordination_v1.md)
 
-2.  [*Infrastructure Description v2*](../tasks/Infrastructure_Description_v2.md)
+2. Coordination: [Infrastructure Description v2](../tasks/Infrastructure_Description_v2.md)
 
-3.  [*Cybersecurity Requirements for RPs v1*](../tasks/Cybersecurity_Requirements_for_RPs_v1.md)
+3. Technology: [Cybersecurity Requirements for RPs v1](../tasks/Cybersecurity_Requirements_for_RPs_v1.md)
 
-4.  [*Data and Network Integration v1*](../tasks/Data_and_Network_Integration.md)
+4. Technology: [Data and Network Integration v1](../tasks/Data_and_Network_Integration.md)
 
-5.  [*ACCESS Allocation Policies v1*](../tasks/ACCESS_Allocation_Policies_v1.md)
+## Integration phase
 
-6.  [*Knowledge Base v1*](../tasks/Knowledge_Base_v1.md)
+5. Coordination: [ACCESS Allocation Policies v1](../tasks/ACCESS_Allocation_Policies_v1.md)
 
-7.  [*RP Forum Participation v1*](../tasks/Resource_Provider_Forum_Participation_v1.md)
+6. Coordination: [Knowledge Base v1](../tasks/Knowledge_Base_v1.md)
 
-8.  [*Cybersecurity Governance Council Participation v1*](../tasks/Cybersecurity_Governance_Council_Participation_v1.md)
+7. Coordination: [RP Forum Participation v1](../tasks/Resource_Provider_Forum_Participation_v1.md)
 
-9.  [*Resource Metrics Data Availability Assessment v1*](../tasks/Resource_Metrics_Data_Availability_Assessment_v1.md)
+8. Coordination: [Cybersecurity Governance Council Participation v1](../tasks/Cybersecurity_Governance_Council_Participation_v1.md)
 
-10. [*Incident Response and Coordination v1*](../tasks/Incident_Response_and_Coordination_v1.md)
+9. Technology: [Resource Metrics Data Availability Assessment v1](../tasks/Resource_Metrics_Data_Availability_Assessment_v1.md)
 
-11. [*Ticket Handling v2*](../tasks/Ticket_Handling_v2.md)
+10. (Optional) Technology: [ACCESS DNS Entries v1](../tasks/ACCESS_DNS_Records_v1.md)
 
-12. [*Operational Status Communications v1*](../tasks/Operational_Status_Communications_v1.md)
+11. (Optional) Technology: [Local Service ACCESS IAM Integration v1](../tasks/Local_Services_ACCESS_IAM_Integration_v1.md)
 
-13. [*AMIE and Usage Reporting v1*](../tasks/AMIE_and_Usage_Reporting_v1.md)
+## Operations phase
 
-14. [*Performance Data reporting v1*](../tasks/Performance_Data_Reporting_v1.md)
+12. Support: [Incident Response and Coordination v1](../tasks/Incident_Response_and_Coordination_v1.md)
 
-## Optional Tasks
+13. Support: [Ticket Handling v2](../tasks/Ticket_Handling_v2.md)
 
-1.  [*ACCESS DNS Entries v1*](../tasks/ACCESS_DNS_Records_v1.md) (NEW)
+14. Support: [Operational Status Communications v1](../tasks/Operational_Status_Communications_v1.md)
 
-2.  [*Local Service ACCESS IAM Integration v1*](../tasks/Local_Services_ACCESS_IAM_Integration_v1.md) (NEW)
+15. (Optional) Support: [Request RP or Site Staff Allocation v1](../tasks/Request_RP_or_Site_Staff_Allocation_v1.md)
 
-3.  [*Request RP or Site Staff Allocation v1*](../tasks/Request_RP_or_Site_Staff_Allocation_v1.md)
+16. Technology: [AMIE and Usage Reporting v1](../tasks/AMIE_and_Usage_Reporting_v1.md)
+
+17. Technology: [Performance Data reporting v1](../tasks/Performance_Data_Reporting_v1.md)
 
 ## Document Management
 
 **Status**: Official
 
-**Official date**: 4/24/2023 4/10/2023
+**Official date**: 04/24/2023 04/10/2023
 
 **Coordinators**: Chris Martin, ACCESS Operations
 
-**Last revised date**: 4/7/2023
+**Last revised date**: 08/22/2023
 
 **Retired date**:

--- a/docs/source/compute/ACCESS_Allocated_Production_Compute_-_Integration_Roadmap_Description.md
+++ b/docs/source/compute/ACCESS_Allocated_Production_Compute_-_Integration_Roadmap_Description.md
@@ -40,60 +40,60 @@ Please track RP integration progress in [*this spreadsheet*](https://docs.google
 
 - [*ACCESS RP Roadmaps FAQ*](https://docs.google.com/document/d/1VwYROB7sh4X_Tqvi_4XIkYD-jffBS4UykS6gEJesuQE/)
 
-### Planning phase
+## Planning phase
 
-1. Coordination: [ACCESS Allocated Resource Integration Coordination v1](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/ACCESS_Allocated_Resource_Integration_Coordination_v1.html) (NEW)
+1. Coordination: [ACCESS Allocated Resource Integration Coordination v1](../tasks/ACCESS_Allocated_Resource_Integration_Coordination_v1.md)
 
-2. Coordination: [Infrastructure Description v2](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/Infrastructure_Description_v2.html)
+2. Coordination: [Infrastructure Description v2](../tasks/Infrastructure_Description_v2.md)
 
-3. Technology: [Cybersecurity Requirements for RPs v1](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/Cybersecurity_Requirements_for_RPs_v1.html)
+3. Technology: [Cybersecurity Requirements for RPs v1](../tasks/Cybersecurity_Requirements_for_RPs_v1.md)
 
-4. Technology: [Data and Network Integration v1](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/Data_and_Network_Integration.html)
+4. Technology: [Data and Network Integration v1](../tasks/Data_and_Network_Integration.md)
 
-### Integration phase
+## Integration phase
 
-5. Coordination: [ACCESS Allocation Policies v1](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/ACCESS_Allocation_Policies_v1.html)
+5. Coordination: [ACCESS Allocation Policies v1](../tasks/ACCESS_Allocation_Policies_v1.md)
 
-6. Coordination: [Knowledge Base v1](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/Knowledge_Base_v1.html)
+6. Coordination: [Knowledge Base v1](../tasks/Knowledge_Base_v1.md)
 
-7. Coordination: [Resource Provider Forum Participation v1](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/Resource_Provider_Forum_Participation_v1.html)
+7. Coordination: [RP Forum Participation v1](../tasks/Resource_Provider_Forum_Participation_v1.md)
 
-8. Coordination: [Cybersecurity Governance Council Participation v1](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/Cybersecurity_Governance_Council_Participation_v1.html)
+8. Coordination: [Cybersecurity Governance Council Participation v1](../tasks/Cybersecurity_Governance_Council_Participation_v1.md)
 
-9. Technology: [Resource Metrics Data Availability Assessment v1](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/Resource_Metrics_Data_Availability_Assessment_v1.html)
+9. Technology: [Resource Metrics Data Availability Assessment v1](../tasks/Resource_Metrics_Data_Availability_Assessment_v1.md)
 
-10. (Optional) Technology: [ACCESS DNS Entries v1](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/ACCESS_DNS_Records_v1.html) (NEW)
+10. (Optional) Technology: [ACCESS DNS Entries v1](../tasks/ACCESS_DNS_Records_v1.md) (NEW)
 
-11. (Optional) Technology: [Local Service ACCESS IAM Integration v1](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/Local_Services_ACCESS_IAM_Integration_v1.html) (NEW)
+11. (Optional) Technology: [Local Service ACCESS IAM Integration v1](../tasks/Local_Services_ACCESS_IAM_Integration_v1.md)
 
-12. (Optional) Technology: [ACCESS OnDemand Portal Integration v1](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/ACCESS_OnDemand_Portal_Integration_v1.html) (NEW)
+12. (Optional) Technology: [ACCESS OnDemand Portal Integration v1](../tasks/ACCESS_OnDemand_Portal_Integration_v1.md)
 
-### Operations phase
+## Operations phase
 
-13. Technology: [Deploy Globus Endpoint v1](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/Deploy_Globus_Endpoint_v1.html)
+13. Technology: [Deploy Globus Endpoint v1](../tasks/Deploy_Globus_Endpoint_v1.md)
 
-14. Technology: [Publish Dynamic Resource Information v2](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/Publish_Dynamic_Resource_Information_v2.html)
+14. Technology: [Publish Dynamic Resource Information v2](../tasks/Publish_Dynamic_Resource_Information_v2.md)
 
-15. Support: [Incident Response and Coordination v1](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/Incident_Response_and_Coordination_v1.html)
+15. Support: [Incident Response and Coordination v1](../tasks/Incident_Response_and_Coordination_v1.md)
 
-16. Support: [Ticket Handling v2](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/Ticket_Handling_v2.html)
+16. Support: [Ticket Handling v2](../tasks/Ticket_Handling_v2.md)
 
-17. Support: [Operational Status Communications v1](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/Operational_Status_Communications_v1.html)
+17. Support: [Operational Status Communications v1](../tasks/Operational_Status_Communications_v1.md)
 
-18. Support: [AMIE and Usage Reporting v1](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/AMIE_and_Usage_Reporting_v1.html)
+18. (Optional) Support: [Request RP or Site Staff Allocation v1](../tasks/Request_RP_or_Site_Staff_Allocation_v1.md)
 
-19. Technology: [Performance Data reporting v1](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/Performance_Data_Reporting_v1.html)
+19. Technology: [AMIE and Usage Reporting v1](../tasks/AMIE_and_Usage_Reporting_v1.md)
 
-20. (Optional) Technology: [Request RP or Site Staff Allocation v1](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/Request_RP_or_Site_Staff_Allocation_v1.html)
+20. Technology: [Performance Data reporting v1](../tasks/Performance_Data_Reporting_v1.md)
 
 ## Document Management
 
 **Status**: Official
 
-**Official date**: 4/24/2023
+**Official date**: 04/24/2023
 
 **Coordinators**: Jess Haney, ACCESS Operations
 
-**Last revised date**: 08/07/2023
+**Last revised date**: 08/22/2023
 
 **Retired date**:

--- a/docs/source/gateway/ACCESS_Integrated_Science_Gateway_-_Integration_Roadmap_Description.md
+++ b/docs/source/gateway/ACCESS_Integrated_Science_Gateway_-_Integration_Roadmap_Description.md
@@ -32,34 +32,31 @@ Operators must perform the Required Tasks below and may perform the Optional Tas
 
 - [*Introduction to Roadmaps*](https://docs.google.com/presentation/d/1OjeT6r01mdOIa4pq1VE0L5ocRPfqdXFp9QsADjdqrjE/) slides
 
-## Required Tasks
+## Planning phase
+1. Coordination: [ACCESS Science Gateway Integration Coordination v1](../tasks/ACCESS_Science_Gateway_Integration_Coordination_v1.md)
 
-1.  [*ACCESS Science Gateway Integration Coordination v1*](../tasks/ACCESS_Science_Gateway_Integration_Coordination_v1.md)
+## Integration/Operations phase(s)
 
-2.  [*Science Gateway Description v1*](../tasks/Science_Gateway_Description_v1.md)
+2. Coordination/Support: [Science Gateway Description v1](../tasks/Science_Gateway_Description_v1.md)
 
-3.  [*Request Science Gateway Allocation v1*](../tasks/Request_Science_Gateway_Allocation_v1.md)
+3. Coordination/Support: [Request Science Gateway Allocation v1](../tasks/Request_Science_Gateway_Allocation_v1.md)
 
-4.  [*Request Science Gateway Resources v1*](../tasks/Request_Science_Gateway_Resources_v1.md)
+4. Coordination/Support: [Request Science Gateway Resources v1](../tasks/Request_Science_Gateway_Resources_v1.md)
 
-5.  [*ACCESS Affinity Groups and Science Gateways v1*](../tasks/ACCESS_Affinity_Groups_and_Science_Gateways_v1.md)
+5. Coordination/Support: [ACCESS Affinity Groups and Science Gateways v1](../tasks/ACCESS_Affinity_Groups_and_Science_Gateways_v1.md)
 
-6.  [*Request Science Gateway Community Accounts v1*](../tasks/Request_Science_Gateway_Community_Accounts_v1.md)
+6. Coordination/Support: [Request Science Gateway Community Accounts v1](../tasks/Request_Science_Gateway_Community_Accounts_v1.md)
 
-7.  [*Science Gateway Usage Reporting v1*](../tasks/Science_Gateway_Usage_Reporting_v1.md)
-
-## Optional Tasks
-
-1.  None
+7. Coordination/Support: [Science Gateway Usage Reporting v1](../tasks/Science_Gateway_Usage_Reporting_v1.md)
 
 ## Document Management
 
 **Status**: Official
 
-**Official date**: 4/24/2023 4/10/2023
+**Official date**: 04/24/2023 04/10/2023
 
 **Coordinators**: Rob Quick, ACCESS Operations
 
-**Last revised date**: 4/3/2023
+**Last revised date**: 08/22/2023
 
 **Retired date**:

--- a/docs/source/onlineservice/ACCESS_Production_Online_Service_-_Integration_Roadmap_Description.md
+++ b/docs/source/onlineservice/ACCESS_Production_Online_Service_-_Integration_Roadmap_Description.md
@@ -26,40 +26,43 @@ See related [*Roadmap Task Timeline*](https://docs.google.com/presentation/d/1GI
 
 - [*Introduction to Roadmaps*](https://docs.google.com/presentation/d/1OjeT6r01mdOIa4pq1VE0L5ocRPfqdXFp9QsADjdqrjE/) slides
 
-## Required Tasks
+## Planning phase
 
-1.  [*Infrastructure Description v2*](../tasks/Infrastructure_Description_v2.md)
+1. Coordination: [Infrastructure Description v2](../tasks/Infrastructure_Description_v2.md)
 
-2.  [*Cybersecurity Requirements for ACCESS Services v1*](../tasks/Cybersecurity_Requirements_for_ACCESS_Services_v1.md)
+2. Technology: [Cybersecurity Requirements for ACCESS Services v1](../tasks/Cybersecurity_Requirements_for_ACCESS_Services_v1.md)
 
-3.  [*Cybersecurity Governance Council Participation v1*](../tasks/Cybersecurity_Governance_Council_Participation_v1.md)
+## Integration phase
 
-4.  [*Online Service Documentation v1*](../tasks/Online_Service_Documentation_v1.md)
+3. Coordination: [Cybersecurity Governance Council Participation v1](../tasks/Cybersecurity_Governance_Council_Participation_v1.md)
 
-5.  [*Incident Response and Coordination v1*](../tasks/Incident_Response_and_Coordination_v1.md)
+4. (Optional) Technology: [ACCESS DNS Entries v1](../tasks/ACCESS_DNS_Records_v1.md)
 
-6.  [*Ticket Handling v2*](../tasks/Ticket_Handling_v2.md)
+5. (Optional) Technology: [Local Service ACCESS IAM Integration v1](../tasks/Local_Services_ACCESS_IAM_Integration_v1.md)
 
-7.  [*Operational Status Communications v1*](../tasks/Operational_Status_Communications_v1.md)
+6. (Optional) Support: [Request RP or Site Staff Allocation v1](../tasks/Request_RP_or_Site_Staff_Allocation_v1.md)
 
-## Optional Tasks
+7. Coordination: [Online Service Documentation v1](../tasks/Online_Service_Documentation_v1.md)
 
-1.  [*ACCESS DNS Records v1*](../tasks/ACCESS_DNS_Records_v1.md)
 
-2.  [*Service ACCESS IAM Integration v1*](../tasks/Local_Services_ACCESS_IAM_Integration_v1.md)
+## Operations phase
 
-3.  [*Request RP or Site Staff Allocation v1*](../tasks/Request_RP_or_Site_Staff_Allocation_v1.md)
+8. Support: [Incident Response and Coordination v1](../tasks/Incident_Response_and_Coordination_v1.md)
 
-4.  [*Performance Data Reporting v1*](../tasks/Performance_Data_Reporting_v1.md)
+9. Support: [Ticket Handling v2](../tasks/Ticket_Handling_v2.md)
+
+10. Support: [Operational Status Communications v1](../tasks/Operational_Status_Communications_v1.md)
+
+11. (Optional) Technology: [Performance Data reporting v1](../tasks/Performance_Data_Reporting_v1.md)
 
 ## Document Management
 
 **Status**: Official
 
-**Official date**: 4/24/2023 5/1/2023
+**Official date**: 04/24/2023 05/01/2023
 
 **Coordinators**: JP Navarro, ACCESS Operations
 
-**Last revised date**: 4/7/2023
+**Last revised date**: 08/22/2023
 
 **Retired date**:

--- a/docs/source/storage/ACCESS_Allocated_Production_Storage_-_Integration_Roadmap_Description.md
+++ b/docs/source/storage/ACCESS_Allocated_Production_Storage_-_Integration_Roadmap_Description.md
@@ -40,54 +40,56 @@ Please track RP integration progress in [*this spreadsheet*](https://docs.google
 
 - [*ACCESS RP Roadmaps FAQ*](https://docs.google.com/document/d/1VwYROB7sh4X_Tqvi_4XIkYD-jffBS4UykS6gEJesuQE/)
 
-## Required Tasks
+## Planning phase
 
-1.  [*ACCESS Allocated Resource Integration Coordination v1*](../tasks/ACCESS_Allocated_Resource_Integration_Coordination_v1.md) (NEW)
+1. Coordination: [ACCESS Allocated Resource Integration Coordination v1](../tasks/ACCESS_Allocated_Resource_Integration_Coordination_v1.md)
 
-2.  [*Infrastructure Description v2*](../tasks/Infrastructure_Description_v2.md)
+2. Coordination: [Infrastructure Description v2](../tasks/Infrastructure_Description_v2.md)
 
-3.  [*Cybersecurity Requirements for RPs v1*](../tasks/Cybersecurity_Requirements_for_RPs_v1.md)
+3. Technology: [Cybersecurity Requirements for RPs v1](../tasks/Cybersecurity_Requirements_for_RPs_v1.md)
 
-4.  [*Data and Network Integration v1*](../tasks/Data_and_Network_Integration.md)
+4. Technology: [Data and Network Integration v1](../tasks/Data_and_Network_Integration.md)
 
-5.  [*ACCESS Allocation Policies v1*](../tasks/ACCESS_Allocation_Policies_v1.md)
+## Integration phase
 
-6.  [*Knowledge Base v1*](../tasks/Knowledge_Base_v1.md)
+5. Coordination: [ACCESS Allocation Policies v1](../tasks/ACCESS_Allocation_Policies_v1.md)
 
-7.  [*RP Forum Participation v1*](../tasks/Resource_Provider_Forum_Participation_v1.md)
+6. Coordination: [Knowledge Base v1](../tasks/Knowledge_Base_v1.md)
 
-8.  [*Cybersecurity Governance Council Participation v1*](../tasks/Cybersecurity_Governance_Council_Participation_v1.md)
+7. Coordination: [RP Forum Participation v1](../tasks/Resource_Provider_Forum_Participation_v1.md)
 
-9.  [*Resource Metrics Data Availability Assessment v1*](../tasks/Resource_Metrics_Data_Availability_Assessment_v1.md)
+8. Coordination: [Cybersecurity Governance Council Participation v1](../tasks/Cybersecurity_Governance_Council_Participation_v1.md)
 
-10. [*Incident Response and Coordination v1*](../tasks/Incident_Response_and_Coordination_v1.md)
+9. Technology: [Resource Metrics Data Availability Assessment v1](../tasks/Resource_Metrics_Data_Availability_Assessment_v1.md)
 
-11. [*Ticket Handling v2*](../tasks/Ticket_Handling_v2.md)
+10. (Optional) Technology: [ACCESS DNS Entries v1](../tasks/ACCESS_DNS_Records_v1.md)
 
-12. [*Operational Status Communications v1*](../tasks/Operational_Status_Communications_v1.md)
+11. (Optional) Technology: [Local Service ACCESS IAM Integration v1](../tasks/Local_Services_ACCESS_IAM_Integration_v1.md)
 
-13. [*AMIE and Usage Reporting v1*](../tasks/AMIE_and_Usage_Reporting_v1.md)
+## Operations phase
 
-14. [*Performance Data reporting v1*](../tasks/Performance_Data_Reporting_v1.md)
+12. Technology: [Deploy Globus Endpoint v1](../tasks/Deploy_Globus_Endpoint_v1.md)
 
-## Optional Tasks
+13. Support: [Incident Response and Coordination v1](../tasks/Incident_Response_and_Coordination_v1.md)
 
-1.  [*ACCESS DNS Entries v1*](../tasks/ACCESS_DNS_Records_v1.md) (NEW)
+14. Support: [Ticket Handling v2](../tasks/Ticket_Handling_v2.md)
 
-2.  [*Local Service ACCESS IAM Integration v1*](../tasks/Local_Services_ACCESS_IAM_Integration_v1.md) (NEW)
+15. Support: [Operational Status Communications v1](../tasks/Operational_Status_Communications_v1.md)
 
-3.  [*Request RP or Site Staff Allocation v1*](../tasks/Request_RP_or_Site_Staff_Allocation_v1.md)
+16. (Optional) Support: [Request RP or Site Staff Allocation v1](../tasks/Request_RP_or_Site_Staff_Allocation_v1.md)
 
-4. [*Deploy Globus Endpoint v1*](../tasks/Deploy_Globus_Endpoint_v1.md)
+17. Technology: [AMIE and Usage Reporting v1](../tasks/AMIE_and_Usage_Reporting_v1.md)
+
+18. Technology: [Performance Data reporting v1](../tasks/Performance_Data_Reporting_v1.md)
 
 ## Document Management
 
 **Status**: Official
 
-**Official date**: 4/24/2023 4/10/2023
+**Official date**: 04/24/2023 04/10/2023
 
 **Coordinators**: Lee Liming, ACCESS Operations
 
-**Last revised date**: 4/7/2023
+**Last revised date**: 08/22/2023
 
 **Retired date**:


### PR DESCRIPTION
This PR is to get all current Roadmaps (Cloud, Compute, Storage, Online Services, Science Gateways) to order tasks by phases (Planning, Integration, Operations) rather than by required/optional.