### PR TITLE
Patch readthedocs-sphinx-search dependency by upgrading Sphinx from 5.3.0 -> 7.2.6 (latest)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,11 +1,21 @@
+---
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
 version: 2
 
+# Build all formats
 formats: all
 
+# See docs/requirements.txt to pin Sphinx/MkDocs to a specific version
 sphinx:
   configuration: docs/source/conf.py
   fail_on_warning: true
 
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
   install:
     - requirements: docs/requirements.txt
@@ -13,7 +23,7 @@ python:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.12"
   jobs:
     post_checkout:
       # https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -1,5 +1,5 @@
-# Defining the exact version will make sure things don't break sphinx==5.3.0
-Sphinx>=5,<6
+# Pin the exact version for dependencies if automatic upgrading is unwanted (e.g sphinx==5.3.0)
+Sphinx
 sphinx_rtd_theme
 readthedocs-sphinx-search
 myst_parser

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,69 +4,72 @@
 #
 #    pip-compile --output-file=docs/requirements.txt docs/requirements.in
 #
-alabaster==0.7.13
+alabaster==0.7.16
     # via sphinx
-babel==2.12.1
+babel==2.14.0
     # via sphinx
-certifi==2022.12.7
+certifi==2023.11.17
     # via requests
-charset-normalizer==3.1.0
+charset-normalizer==3.3.2
     # via requests
-docutils==0.17.1
+docutils==0.20.1
     # via
     #   myst-parser
     #   sphinx
     #   sphinx-rtd-theme
-idna==3.4
+idna==3.6
     # via requests
 imagesize==1.4.1
     # via sphinx
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   myst-parser
     #   sphinx
-markdown-it-py==2.2.0
+markdown-it-py==3.0.0
     # via
     #   mdit-py-plugins
     #   myst-parser
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
-mdit-py-plugins==0.3.5
+mdit-py-plugins==0.4.0
     # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
-myst-parser==0.19.1
-    # via -r requirements.in
-packaging==23.0
+myst-parser==2.0.0
+    # via -r docs/requirements.in
+packaging==23.2
     # via sphinx
-pygments==2.14.0
+pygments==2.17.2
     # via sphinx
-pyyaml==6.0
+pyyaml==6.0.1
     # via myst-parser
-readthedocs-sphinx-search==0.1.1
-    # via -r requirements.in
+readthedocs-sphinx-search==0.3.2
+    # via -r docs/requirements.in
 requests==2.31.0
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.3.0
+sphinx==7.2.6
     # via
-    #   -r requirements.in
+    #   -r docs/requirements.in
     #   myst-parser
     #   sphinx-rtd-theme
-sphinx-rtd-theme==1.1.1
-    # via -r requirements.in
-sphinxcontrib-applehelp==1.0.4
+    #   sphinxcontrib-jquery
+sphinx-rtd-theme==2.0.0
+    # via -r docs/requirements.in
+sphinxcontrib-applehelp==1.0.8
     # via sphinx
-sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-devhelp==1.0.6
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-htmlhelp==2.0.5
     # via sphinx
+sphinxcontrib-jquery==4.1
+    # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-qthelp==1.0.7
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
-urllib3==1.26.14
+urllib3==2.1.0
     # via requests


### PR DESCRIPTION
This PR is intended to fix the [readthedocs-sphinx-search security vulnerability](https://github.com/readthedocs/readthedocs-sphinx-search/security/advisories/GHSA-xgfm-fjx6-62mj) by unpinning the Sphinx version to ensure the latest version.

My thinking is that we should allow continuous updates by default, and pin package versions when necessary (after build failures) to ensure ease of repository management. Please raise issues if you disagree!

Python version continues to be explicitly defined and this PR includes upgrading from Python 3.10 -> 3.12 (latest) to keep us up-to-date. I will revert the Python upgrade if it causes the build fails.

resolves #72