### PR TITLE
Fix typos in a couple of Metrics tasks

### DIFF
--- a/docs/source/tasks/Performance_Data_Reporting_v1.md
+++ b/docs/source/tasks/Performance_Data_Reporting_v1.md
@@ -41,11 +41,11 @@ Option (3) can only be used if the resource supports ACCESS community accounts a
 
 ## Document Management
 
-**Status**: {Draft, Official, Retired}
+**Status**: Official
 
-**Official date**: 4/24/2023 \<mm/dd/yyyy\>
+**Official date**: 4/24/2023
 
-**Coordinators**: **\<name\>, \<ACCESS project\>**
+**Coordinators**: Joseph White, ACCESS Metrics
 
 **Last revised date**: 2023-02-01
 

--- a/docs/source/tasks/Resource_Metrics_Data_Availability_Assessment_v1.md
+++ b/docs/source/tasks/Resource_Metrics_Data_Availability_Assessment_v1.md
@@ -31,12 +31,12 @@ If the CI resource is not collecting performance data then this should be report
 
 ## Document Management
 
-**Status**: {Draft, Official, Retired}
+**Status**: Official
 
-**Official date**: 4/24/2023 \<mm/dd/yyyy\>
+**Official date**: 4/24/2023
 
 **Coordinators**: Joseph White, ACCESS Metrics
 
 **Last revised date**: 2023-02-01
 
-**Retired date**: \<mm/dd/yyyy\> or blank
+**Retired date**:


### PR DESCRIPTION
Looks like some leftover stuff from the original template was left in the docs. Since there were no material changes to the tasks I have left the revision dates unchanged.