### PR TITLE
Use new format of document metadata footer for cloud roadmap and associated tasks

### DIFF
--- a/docs/source/cloud/ACCESS_Allocated_Production_Cloud_-_Integration_Roadmap_Description.md
+++ b/docs/source/cloud/ACCESS_Allocated_Production_Cloud_-_Integration_Roadmap_Description.md
@@ -76,14 +76,12 @@ See related [*Roadmap Task Timeline*](https://docs.google.com/presentation/d/1ez
 
 17. Technology: [Performance Data reporting v1](../tasks/Performance_Data_Reporting_v1.md)
 
-## Document Management
-
-**Status**: Official
-
-**Official date**: 04/24/2023 04/10/2023
-
-**Coordinators**: Chris Martin, ACCESS Operations
-
-**Last revised date**: 08/22/2023
-
-**Retired date**:
+<sub>
+<ul class="document-meta-data">
+    <li><strong>Status</strong> : Production</li>
+    <li><strong>Version</strong> : v1</li>
+    <li><strong>Task Expert(s)</strong> : Chris Martin, ACCESS Operations</li>
+</ul>
+</sub>
+<br/>
+<br/>

--- a/docs/source/tasks/ACCESS_Allocated_Resource_Integration_Coordination_v1.md
+++ b/docs/source/tasks/ACCESS_Allocated_Resource_Integration_Coordination_v1.md
@@ -67,14 +67,13 @@ The Integration Coordinator is responsible for maintaining accurate contact info
 
 ACCESS Integration Roadmaps task lists which RP staff contacts normally perform that task.
 
-## Document Management
-
-**Status**: Official
-
-**Official date**: 4/24/2023 2/1/2023
-
-**Coordinators**: JP Navarro, ACCESS Operations
-
-**Last revised date**: 1/17/2023
-
-**Retired date**:
+<sub>
+<ul class="document-meta-data">
+    <li><strong>Status</strong> : Production</li>
+    <li><strong>Version</strong> : v1</li>
+    <li><strong>Task Expert(s)</strong> : JP Navarro, ACCESS Operations
+    </li>
+</ul>
+</sub>
+<br/>
+<br/>

--- a/docs/source/tasks/ACCESS_Allocation_Policies_v1.md
+++ b/docs/source/tasks/ACCESS_Allocation_Policies_v1.md
@@ -124,15 +124,12 @@ Some additional links that may be of benefit to RPs:
 
 Thank you for providing your essential expertise and assistance to the ACCESS ecosystem!
 
-
-## Document Management
-
-**Status**: Official
-
-**Official date**: 4/24/2023 1/23/2023
-
-**Coordinators**: Ken Hackworth, ACCESS Allocations
-
-**Last revised date**: 6/8/2023
-
-**Retired date**:
+<sub>
+<ul class="document-meta-data">
+    <li><strong>Status</strong> : Production</li>
+    <li><strong>Version</strong> : v1</li>
+    <li><strong>Task Expert(s)</strong> : Ken Hackworth, ACCESS Allocations</li>
+</ul>
+</sub>
+<br/>
+<br/>

--- a/docs/source/tasks/AMIE_and_Usage_Reporting_v1.md
+++ b/docs/source/tasks/AMIE_and_Usage_Reporting_v1.md
@@ -27,14 +27,12 @@ The AMIE documentation also contains information about the Usage Reporting API. 
 
 The RP will be expected to maintain a technical contact with the Allocations team, to be able to respond to technical questions or error reports, or to adjust the client implementation as needed in the future.
 
-## Document Management
-
-**Status**: Official
-
-**Official date**: 4/24/2023 1/23/2023
-
-**Coordinators**: Nathan Tolber & Rob Light, ACCESS Allocations
-
-**Last revised date**: 1/23/2023
-
-**Retired date**:
+<sub>
+<ul class="document-meta-data">
+    <li><strong>Status</strong> : Production</li>
+    <li><strong>Version</strong> : v1</li>
+    <li><strong>Task Expert(s)</strong> : Nathan Tolber & Rob Light, ACCESS Allocations</li>
+</ul>
+</sub>
+<br/>
+<br/>

--- a/docs/source/tasks/Cybersecurity_Governance_Council_Participation_v1.md
+++ b/docs/source/tasks/Cybersecurity_Governance_Council_Participation_v1.md
@@ -47,14 +47,12 @@ Additional links
 
 - [*ACCESS Cybersecurity Governance Council Meeting Minutes*](https://docs.google.com/document/d/1SvpJVFRPjpzS0FoXMtSMpoFa0eRHzfjSq5YqQtLUrqc/edit)
 
-## Document Management
-
-**Status**: Official
-
-**Official date**: 4/24/2023 \<mm/dd/yyyy\>
-
-**Coordinators**: Derek Simmel & Shane Filus, CONECT Cybersecurity Program
-
-**Last revised date**: 04/16/2023
-
-**Retired date**:
+<sub>
+<ul class="document-meta-data">
+    <li><strong>Status</strong> : Production</li>
+    <li><strong>Version</strong> : v1</li>
+    <li><strong>Task Expert(s)</strong> : Derek Simmel & Shane Filus, CONECT Cybersecurity Program</li>
+</ul>
+</sub>
+<br/>
+<br/>

--- a/docs/source/tasks/Cybersecurity_Requirements_for_RPs_v1.md
+++ b/docs/source/tasks/Cybersecurity_Requirements_for_RPs_v1.md
@@ -61,14 +61,12 @@ Requirements for this review are driven by ACCESS community policies, listed bel
 
 4.  Make any local security and privacy policies available and easy to find for ACCESS users who may be running jobs on their systems. For example Acceptable Use, Incident Response, etc.
 
-## Document Management
-
-**Status**: Official
-
-**Official date**: 4/24/2023
-
-**Coordinators**: Derek Simmel & Shane Filus, CONECT Cybersecurity Program
-
-**Last revised date**: 07/13/2023
-
-**Retired date**:
+<sub>
+<ul class="document-meta-data">
+    <li><strong>Status</strong> : Production</li>
+    <li><strong>Version</strong> : v1</li>
+    <li><strong>Task Expert(s)</strong> : Derek Simmel & Shane Filus, CONECT Cybersecurity Program</li>
+</ul>
+</sub>
+<br/>
+<br/>

--- a/docs/source/tasks/Data_and_Network_Integration.md
+++ b/docs/source/tasks/Data_and_Network_Integration.md
@@ -91,16 +91,14 @@ The supported file transfer applications for ACCESS are currently scp, sftp, rsy
 
 Globus requires specific system, application, and (potentially) hardware configuration. Please see the ACCESS CONECT document [**Deploy Globus Endpoint**](Deploy_Globus_Endpoint_v1.md) for detailed guidance.
 
-## Document Management
-
-**Status**: Official
-
-**Official date**: 4/24/2023 \<mm/dd/yyyy\>
-
-**Coordinators**: Kathy Benninger, ACCESS Operations
-
-**Last revised date**: 3/11/2023
-
-**Retired date**:
+<sub>
+<ul class="document-meta-data">
+    <li><strong>Status</strong> : Production</li>
+    <li><strong>Version</strong> : v1</li>
+    <li><strong>Task Expert(s)</strong> : Kathy Benninger, ACCESS Operations</li>
+</ul>
+</sub>
+<br/>
+<br/>
 
 [1] If jumbo frames are not configured, Path MTU Discovery must be enabled across the end-to-end path.

--- a/docs/source/tasks/Incident_Response_and_Coordination_v1.md
+++ b/docs/source/tasks/Incident_Response_and_Coordination_v1.md
@@ -43,14 +43,12 @@ Submit an ACCESS ticket using the [*Support Portal ticket form*](https://support
 
 You will receive a response from ACCESS CONECT Cybersecurity Group indicating that the individuals have been added to the ACCESS ACCESS Incident Response Trust Group (AIRTG) and the secure communication channels outlined in the effort section above.
 
-## Document Management
-
-**Status**: Official
-
-**Official date**: 4/24/2023
-
-**Coordinators**: Derek Simmel & Shane Filus, CONECT Cybersecurity Program
-
-**Last revised date**: 07/13/2023
-
-**Retired date**:
+<sub>
+<ul class="document-meta-data">
+    <li><strong>Status</strong> : Production</li>
+    <li><strong>Version</strong> : v1</li>
+    <li><strong>Task Expert(s)</strong> : Derek Simmel & Shane Filus, CONECT Cybersecurity Program</li>
+</ul>
+</sub>
+<br/>
+<br/>

--- a/docs/source/tasks/Infrastructure_Description_v2.md
+++ b/docs/source/tasks/Infrastructure_Description_v2.md
@@ -131,14 +131,12 @@ Page 16 of the CiDeR Manual has instructions for entering a “conversion factor
 
 Information in CiDeR must be kept up to date and reviewed for accuracy at least yearly.
 
-## Document Management
-
-**Status**: Official
-
-**Official date**: 4/24/2023 2/15/2023
-
-**Coordinators**: JP Navarro, ACCESS Operations; Nathan Tolbert, ACCESS Allocations
-
-**Last revised date**: 2/3/2023
-
-**Retired date**:
+<sub>
+<ul class="document-meta-data">
+    <li><strong>Status</strong> : Production</li>
+    <li><strong>Version</strong> : v1</li>
+    <li><strong>Task Expert(s)</strong> : JP Navarro, ACCESS Operations; Nathan Tolbert, ACCESS Allocations</li>
+</ul>
+</sub>
+<br/>
+<br/>

--- a/docs/source/tasks/Knowledge_Base_v1.md
+++ b/docs/source/tasks/Knowledge_Base_v1.md
@@ -47,14 +47,12 @@ Please submit news items via the ASP Portal. You will see a box on the right sid
 
 Please submit events via the ASP Portal. This link will take you to a listing of all events in a calendar format. You will see a box on the right side that says *“Posting Events, Do you have events or training you would like to share with the ACCESS community?”* which will take you to a page that asks for specific details of your event you would like to post. This can also be shared with your Affinity group. You will need to be signed-in to ACCESS to submit.
 
-## Document Management
-
-**Status**: Official
-
-**Official date**: 4/24/2023 01/27/2023
-
-**Coordinators**: Alana Romanella, ACCESS Support
-
-**Last revised date**: 01/27/2023
-
-**Retired date**:
+<sub>
+<ul class="document-meta-data">
+    <li><strong>Status</strong> : Production</li>
+    <li><strong>Version</strong> : v1</li>
+    <li><strong>Task Expert(s)</strong> : Alana Romanella, ACCESS Support</li>
+</ul>
+</sub>
+<br/>
+<br/>

--- a/docs/source/tasks/Operational_Status_Communications_v1.md
+++ b/docs/source/tasks/Operational_Status_Communications_v1.md
@@ -69,14 +69,12 @@ Resource providers and ACCESS projects may access infrastructure news through an
 
 Under the “News” section.
 
-## Document Management
-
-**Status**: Official
-
-**Official date**: 4/24/2023
-
-**Coordinators**: JP Navarro, ACCESS Operations
-
-**Last revised date**: 6/8/2023
-
-**Retired date**:
+<sub>
+<ul class="document-meta-data">
+    <li><strong>Status</strong> : Production</li>
+    <li><strong>Version</strong> : v1</li>
+    <li><strong>Task Expert(s)</strong> : JP Navarro, ACCESS Operations</li>
+</ul>
+</sub>
+<br/>
+<br/>

--- a/docs/source/tasks/Performance_Data_Reporting_v1.md
+++ b/docs/source/tasks/Performance_Data_Reporting_v1.md
@@ -39,14 +39,12 @@ If option (2) is chosen then the RP should provide an ssh public key and a prefe
 
 Option (3) can only be used if the resource supports ACCESS community accounts and the “Community User xdtas” is authorized. In this case the xdtas account must have read permissions on the low-level performance data files. ACCESS Metrics will manage the periodic transfers.
 
-## Document Management
-
-**Status**: Official
-
-**Official date**: 4/24/2023
-
-**Coordinators**: Joseph White, ACCESS Metrics
-
-**Last revised date**: 2023-02-01
-
-**Retired date**:
+<sub>
+<ul class="document-meta-data">
+    <li><strong>Status</strong> : Production</li>
+    <li><strong>Version</strong> : v1</li>
+    <li><strong>Task Expert(s)</strong> : Joseph White, ACCESS Metrics</li>
+</ul>
+</sub>
+<br/>
+<br/>

--- a/docs/source/tasks/Resource_Metrics_Data_Availability_Assessment_v1.md
+++ b/docs/source/tasks/Resource_Metrics_Data_Availability_Assessment_v1.md
@@ -29,14 +29,12 @@ If the CI resource is already collecting performance data (or data collection is
 
 If the CI resource is not collecting performance data then this should be reported to the ACCESS Metrics team via the Support Contact and we will start the discussion about what are the appropriate performance metrics to collect and the most efficient mechanism used to collect this. For traditional HPC resources, performance data collection is typically achieved by running monitoring software on the compute nodes. Examples of such software include [*tacc_stats*](https://github.com/TACC/tacc_stats), [*Performance Co-Pilot*](https://pcp.io/) [*Prometheus*](https://prometheus.io/) or [*Ganglia*](http://ganglia.sourceforge.net/). ACCESS Metrics can provide guidance and recommendations for the most appropriate tool for the task. ACCESS Metrics team members maintain the [*tacc_stats*](https://github.com/TACC/tacc_stats) software and can provide expert assistance with integration. ACCESS Metrics supports [*Performance Co-Pilot*](https://pcp.io/) and [*Prometheus*](https://prometheus.io/) for Open XDMoD and can also provide assistance with install and configuration.
 
-## Document Management
-
-**Status**: Official
-
-**Official date**: 4/24/2023
-
-**Coordinators**: Joseph White, ACCESS Metrics
-
-**Last revised date**: 2023-02-01
-
-**Retired date**:
+<sub>
+<ul class="document-meta-data">
+    <li><strong>Status</strong> : Production</li>
+    <li><strong>Version</strong> : v1</li>
+    <li><strong>Task Expert(s)</strong> : Joseph White, ACCESS Metrics</li>
+</ul>
+</sub>
+<br/>
+<br/>

--- a/docs/source/tasks/Resource_Provider_Forum_Participation_v1.md
+++ b/docs/source/tasks/Resource_Provider_Forum_Participation_v1.md
@@ -37,14 +37,12 @@ The PI, co-PI, or Resource Integration Coordinator submit a request to join the 
 
 Within 2 weeks you will receive a response from the RP Forum Coordinator, and the designated RP Forum participants will start receiving RP Forum meeting invites and other communications through an RP Forum email list.
 
-## Document Management
-
-**Status**: Official
-
-**Official date**: 4/24/2023 2023/02/01
-
-**Coordinators**: Jeremy Fischer, RP Forum Chair & Nicole Wolter, RP Forum Vice-Chair
-
-**Last revised date**: 2024/03/28
-
-**Retired date**:
+<sub>
+<ul class="document-meta-data">
+    <li><strong>Status</strong> : Production</li>
+    <li><strong>Version</strong> : v1</li>
+    <li><strong>Task Expert(s)</strong> : Jeremy Fischer, RP Forum Chair & Nicole Wolter, RP Forum Vice-Chair</li>
+</ul>
+</sub>
+<br/>
+<br/>


### PR DESCRIPTION
Makes similar changes as #79 for the cloud roadmap and its associated tasks.