### PR TITLE
Update instructions for Utilization Reporting for non-ACCESS allocated resources.

### DIFF
--- a/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
+++ b/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
@@ -230,11 +230,11 @@ while [[ "$date" < "$end_date_exclusive_formatted" ]]; do
         --starttime ${date}T00:00:00 --endtime ${date}T23:59:59 \
         > $file
     response=$(curl -s -H @"$token_file" -F file=@$file $url)
+    rm -f $file
     if [ "$response" != '{"status":"success"}' ]; then
         echo $response >&2
         exit 1
     fi
-    rm -f $file
     date=$(date -d "$date + 1 day" $date_format)
 done
 ```

--- a/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
+++ b/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
@@ -61,9 +61,10 @@ the Globus Transfer mechanism is more appropriate for large file transfers (but 
 ### REST data transfer
 
 To send data to ACCESS via REST you need an API Token. We will generate one and
-email it to you. The token should be saved in a file with the following
-contents, replacing `TOKEN` with your token, and setting permissions so only
-the file owner can read it:
+email it to you. The token should be saved in a file on the system from which
+the files will be sent. The token file should have the following contents,
+replacing `TOKEN` with your token, and setting permissions so only the file
+owner can read it:
 
 ```
 Authorization: Bearer TOKEN

--- a/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
+++ b/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
@@ -200,7 +200,7 @@ fi
 start_date_inclusive_formatted=$(date -d "$start_date" $date_format)
 yesterday=$(date -d '-1 day' $date_format)
 if [[ "$end_date_inclusive_formatted" > "$yesterday" ]]; then
-    echo "$script_name: end date cannot be greater than yesterday" >&2
+    echo "$script_name: end date cannot be after yesterday" >&2
     exit 1
 fi
 if [[ "$start_date_inclusive_formatted" > "$end_date_inclusive_formatted" ]]; then

--- a/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
+++ b/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
@@ -86,7 +86,7 @@ at the top for information on usage.
 #!/bin/bash
 
 ###############################################################################
-# post-sacct-to-ccr.sh
+# post-sacct-to-ccr.sh v2024-09-20
 #
 # Send sacct logs via cURL HTTPS POST requests to the XDMoD team at the
 # University at Buffalo Center for Computational Research (CCR).
@@ -261,6 +261,6 @@ To setup Globus Transfer, please provide the name or names of the globus account
 
 **Coordinators**: **Joseph White, ACCESS Metrics**
 
-**Last revised date**: 2024-07-31
+**Last revised date**: 2024-09-20
 
 **Retired date**:

--- a/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
+++ b/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
@@ -83,13 +83,11 @@ An example Bash script for sending `sacct` logs is shown below. See the comment
 at the top for information on usage.
 
 ```bash
-post-sacct-to-ccr.sh:
-```
-
-```bash
 #!/bin/bash
 
 ###############################################################################
+# post-sacct-to-ccr.sh
+#
 # Send sacct logs via cURL HTTPS POST requests to the XDMoD team at the
 # University at Buffalo Center for Computational Research (CCR).
 #

--- a/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
+++ b/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
@@ -183,7 +183,7 @@ if [ -n "$day_count" ]; then
     fi
     if [ -n "$start_date" ]; then
         start_date_inclusive_formatted=$(date -d "$start_date" $date_format)
-        end_date="$start_date_inclusive_formatted + $day_count days - 1 days"
+        end_date="$start_date_inclusive_formatted + $day_count days - 1 day"
     fi
 fi
 if [ -z "$start_date" ] && [ -z "$end_date" ]; then

--- a/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
+++ b/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
@@ -229,9 +229,11 @@ while [[ "$date" < "$end_date_exclusive_formatted" ]]; do
         --allclusters --allusers \
         --starttime ${date}T00:00:00 --endtime ${date}T23:59:59 \
         > $file
-    curl -H @"$token_file" -F file=@$file $url
-    # Print a newline for readability since the response doesn't include one.
-    echo ''
+    response=$(curl -s -H @"$token_file" -F file=@$file $url)
+    if [ "$response" != '{"status":"success"}' ]; then
+        echo $response >&2
+        exit 1
+    fi
     rm -f $file
     date=$(date -d "$date + 1 day" $date_format)
 done

--- a/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
+++ b/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
@@ -83,6 +83,10 @@ An example Bash script for sending `sacct` logs is shown below. See the comment
 at the top for information on usage.
 
 ```bash
+post-sacct-to-ccr.sh:
+```
+
+```bash
 #!/bin/bash
 
 ###############################################################################

--- a/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
+++ b/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
@@ -231,7 +231,7 @@ while [[ "$date" < "$end_date_exclusive_formatted" ]]; do
         --allclusters --allusers \
         --starttime ${date}T00:00:00 --endtime ${date}T23:59:59 \
         > $file
-    response=$(curl -s -H @"$token_file" -F file=@$file $url)
+    response=$(curl -sS -H @"$token_file" -F file=@$file $url)
     rm -f $file
     if [ "$response" != '{"status":"success"}' ]; then
         echo $response >&2

--- a/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
+++ b/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
@@ -219,6 +219,6 @@ To setup Globus Transfer, please provide the name or names of the globus account
 
 **Coordinators**: **Joseph White, ACCESS Metrics**
 
-**Last revised date**: 2023-09-15
+**Last revised date**: 2024-07-31
 
 **Retired date**:

--- a/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
+++ b/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
@@ -55,53 +55,148 @@ mechanism. The choice of data transfer mechanism depends on the RP preferences:
 
 1.  Globus Transfer with scheduled transfers
 
-The REST endpoint data transfer mechanism is preferred for small amounts of log data transfer (less than 1 MB per day).
+The REST endpoint data transfer mechanism is preferred for small amounts of log data transfer (less than 2 GB per day).
 the Globus Transfer mechanism is more appropriate for large file transfers (but can be used for smaller amounts of data if desired).
 
 ### REST data transfer
 
 To send data to ACCESS via REST you need an API Token. We will generate one and
-email it to you. Below are examples of how to send the data using `curl` and
-how to send data using a python script.
+email it to you. The token should be saved in a file with the following
+contents, replacing `TOKEN` with your token:
 
-Example of data transfer using `curl` command line tool:
 ```
-curl --form file='@FILE_TO_UPLOAD' -H 'Content-Type: text/plain' -H "Authorization: Bearer YOUR_TOKEN_HERE" https://data.ccr.xdmod.org/logs
+Authorization: Bearer TOKEN
 ```
-where `YOUR_TOKEN_HERE` should be set to the token that was provided to you by ACCESS Metrics and `FILE_TO_UPLOAD` should be set
-to the filename of the file to upload (note the '@' character before the filename is required).
 
-Example python script to upload the file using the python requests library:
+Below is an example of how to send a file to the `resource-manager-logs`
+endpoint using `curl`, replacing `FILE` with the path to the file to send and
+`TOKEN_FILE` with the path to the token file (note the `@` is required in both
+cases):
+
 ```
-#!/usr/bin/env python3
+curl -H @TOKEN_FILE -F file=@FILE https://data.ccr.xdmod.org/resource-manager-logs
+```
 
-# Tool for POSTing data from standard input to the UB CCR XDMoD data endpoint.
-# Replace 'YOUR_TOKEN_HERE' below with the API token you received from the
-# XDMoD team.
+An example Bash script for sending `sacct` logs is shown below. See the comment
+at the top for information on usage.
 
-import requests
-import sys
+```bash
+#!/bin/bash
 
-def main():
-    if len(sys.argv) < 2:
-        print("Usage: {} [FILENAME]".format(sys.argv[0]))
-        return
+###############################################################################
+# Send sacct logs via cURL HTTPS POST requests to the XDMoD team at the       #
+# University at Buffalo Center for Computational Research (CCR).              #
+#                                                                             #
+# By default, sends a log of yesterday's jobs.                                #
+#                                                                             #
+# - The default number of days to send is 1, can be changed with the -n       #
+#   option, and must be an integer.                                           #
+# - The default start date of logs to send is today minus the number of       #
+#   days to send. A different start date can be set via the -s option and can #
+#   be in any format recognized by the command `date -d`. The latest day of   #
+#   logs that can be sent is yesterday; thus, start date plus number of days  #
+#   to send must not be greater than today.                                   #
+#                                                                             #
+# Requires an API token provided by the XDMoD team at CCR. A file should be   #
+# created with the following contents, replacing TOKEN with the token, and    #
+# only the user running this script should have read permissions to it:       #
+#                                                                             #
+#     Authorization: Bearer TOKEN                                             #
+#                                                                             #
+# This script will look for the token file at ~/.xdmod-ccr-api-token          #
+# The path to the token file can be changed with the -t option.               #
+#                                                                             #
+# A temporary directory will be created at /tmp/post-sacct-to-ccr, and        #
+# temporary files will be created in that directory, sent, and then deleted.  #
+# The temporary directory path can be changed with the -d option.             #
+#                                                                             #
+# If you have any questions, comments, or concerns, you can contact the XDMoD #
+# team the following ways:                                                    #
+# - For ACCESS RPs, please create a ticket at                                 #
+#   https://support.access-ci.org/open-a-ticket and for the "ACCESS User      #
+#   Support Issue," choose "XDMOD Question."                                  #
+# - Otherwise, please send email to ccr-xdmod-help@buffalo.edu                #
+###############################################################################
 
-    api_token = 'YOUR_TOKEN_HERE'
+# Exit if any command fails.
+set -eo pipefail
 
-    file = {'file': open(sys.argv[1], 'rb')}
-    response = requests.post(
-        'https://data.ccr.xdmod.org/logs',
-        files=file,
-        headers={
-            'content-type': 'text/plain',
-            'authorization': 'Bearer ' + api_token,
-        },
-    )
-    print('Response: ', response.status_code, response.text)
+script_name='post-sacct-to-ccr.sh'
+url='https://data.ccr.xdmod.org/resource-manager-logs'
 
-if __name__ == '__main__':
-    main()
+# Parse arguments.
+while getopts ':n:s:t:d:' opt; do
+    case $opt in
+        s)
+            start_date="$OPTARG"
+            ;;
+        n)
+            day_count="$OPTARG"
+            ;;
+        t)
+            token_file="$OPTARG"
+            ;;
+        d)
+            tmp_dir="$OPTARG"
+            ;;
+        \?)
+            echo "$script_name: invalid option -$OPTARG" >&2
+            exit 1
+            ;;
+        :)
+            echo "$script_name: missing argument for -$OPTARG" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Validate arguments.
+if [ -z "$day_count" ]; then
+    day_count=1
+fi
+if [[ ! "$day_count" =~ ^[0-9]+$ || "$day_count" -lt 1 ]]; then
+    echo "$script_name: day count must be a positive integer" >&2
+    exit 1
+fi
+if [ -z "$start_date" ]; then
+    start_date=$(date -d "$day_count days ago")
+fi
+date_format=+'%Y-%m-%d'
+start_date=$(date -d "$start_date" $date_format)
+end_date=$(date -d "$start_date + $day_count days" $date_format)
+today=$(date $date_format)
+if [[ "$end_date" > "$today" ]]; then
+    echo "$script_name: day count too large, start date ($start_date) plus number of days ($day_count) would go past yesterday" >&2
+    exit 1
+fi
+if [ -z "$token_file" ]; then
+    token_file=~/.xdmod-ccr-api-token
+fi
+if [ ! -f "$token_file" ]; then
+    echo "$script_name: token file '$token_file' does not exist" >&2
+    exit 1
+fi
+if [ -z "$tmp_dir" ]; then
+    tmp_dir='/tmp/post-sacct-to-ccr'
+fi
+
+# Make the temporary directory.
+mkdir -p $tmp_dir
+
+# For each day, create, send, and delete the log file.
+date=$start_date
+while [[ "$date" < "$end_date" ]]; do
+    file=$tmp_dir/$date.json
+    TZ=UTC sacct --duplicates --json --noheader \
+        --allclusters --allusers \
+        --starttime ${date}T00:00:00 --endtime ${date}T23:59:59 \
+        > $file
+    curl -H @"$token_file" -F file=@$file $url
+    # Print a newline for readability since the response doesn't include one.
+    echo ''
+    rm -f $file
+    date=$(date -d "$date + 1 day" $date_format)
+done
 ```
 
 ### Globus Transfer

--- a/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
+++ b/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
@@ -188,7 +188,7 @@ if [ -n "$day_count" ]; then
         end_date="$start_date_inclusive_formatted + $day_count days - 1 day"
     fi
 fi
-if [ -z "$start_date" ] && [ -z "$end_date" ]; then
+if [ -z "$end_date" ]; then
     end_date='-1 day'
 fi
 end_date_inclusive_formatted=$(date -d "$end_date" $date_format)

--- a/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
+++ b/docs/source/tasks/NonACCESSUtilizationReporting_v1.md
@@ -62,7 +62,8 @@ the Globus Transfer mechanism is more appropriate for large file transfers (but 
 
 To send data to ACCESS via REST you need an API Token. We will generate one and
 email it to you. The token should be saved in a file with the following
-contents, replacing `TOKEN` with your token:
+contents, replacing `TOKEN` with your token, and setting permissions so only
+the file owner can read it:
 
 ```
 Authorization: Bearer TOKEN


### PR DESCRIPTION
This PR updates the instructions for sending utilization information to the Metrics team for non-ACCESS allocated resources. Specifically, it updates the file size limit mentioned for making REST requests, updates the example `curl` command to send to the new `/resource-manager-logs` endpoint, provides a Bash script that can be used to send `sacct` logs to that endpoint, and removes the example Python code until that code can be rewritten and tested.

The proposed new roadmap HTML can be viewed [here](https://readthedocs-access-ci-org--85.org.readthedocs.build/projects/integration-roadmaps/en/85/tasks/NonACCESSUtilizationReporting_v1.html).