### PR TITLE
Do not display task document version numbers, other small fixes

### DIFF
--- a/docs/source/cloud/ACCESS_Allocated_Production_Cloud_-_Integration_Roadmap_Description.md
+++ b/docs/source/cloud/ACCESS_Allocated_Production_Cloud_-_Integration_Roadmap_Description.md
@@ -38,43 +38,43 @@ See related [*Roadmap Task Timeline*](https://docs.google.com/presentation/d/1ez
 
 ## Planning phase
 
-1. Coordination: [ACCESS Allocated Resource Integration Coordination v2](../tasks/ACCESS_Allocated_Resource_Integration_Coordination_v2.md)
+1. Coordination: [ACCESS Allocated Resource Integration Coordination](../tasks/ACCESS_Allocated_Resource_Integration_Coordination_v2.md)
 
-2. Coordination: [Infrastructure Description v2](../tasks/Infrastructure_Description_v2.md)
+2. Coordination: [Infrastructure Description](../tasks/Infrastructure_Description_v2.md)
 
-3. Technology: [Cybersecurity Requirements for RPs v1](../tasks/Cybersecurity_Requirements_for_RPs_v1.md)
+3. Technology: [Cybersecurity Requirements for RPs](../tasks/Cybersecurity_Requirements_for_RPs_v1.md)
 
-4. Technology: [Data and Network Integration v1](../tasks/Data_and_Network_Integration.md)
+4. Technology: [Data and Network Integration](../tasks/Data_and_Network_Integration.md)
 
 ## Integration phase
 
-5. Coordination: [ACCESS Allocation Policies v1](../tasks/ACCESS_Allocation_Policies_v1.md)
+5. Coordination: [ACCESS Allocation Policies](../tasks/ACCESS_Allocation_Policies_v1.md)
 
-6. Coordination: [Knowledge Base v1](../tasks/Knowledge_Base_v1.md)
+6. Coordination: [Knowledge Base](../tasks/Knowledge_Base_v1.md)
 
-7. Coordination: [RP Forum Participation v1](../tasks/Resource_Provider_Forum_Participation_v1.md)
+7. Coordination: [RP Forum Participation](../tasks/Resource_Provider_Forum_Participation_v1.md)
 
-8. Coordination: [Cybersecurity Governance Council Participation v1](../tasks/Cybersecurity_Governance_Council_Participation_v1.md)
+8. Coordination: [Cybersecurity Governance Council Participation](../tasks/Cybersecurity_Governance_Council_Participation_v1.md)
 
-9. Technology: [Resource Metrics Data Availability Assessment v1](../tasks/Resource_Metrics_Data_Availability_Assessment_v1.md)
+9. Technology: [Resource Metrics Data Availability Assessment](../tasks/Resource_Metrics_Data_Availability_Assessment_v1.md)
 
-10. (Optional) Technology: [ACCESS DNS Entries v1](../tasks/ACCESS_DNS_Records_v1.md)
+10. (Optional) Technology: [ACCESS DNS Entries](../tasks/ACCESS_DNS_Records_v1.md)
 
-11. (Optional) Technology: [Local Service ACCESS IAM Integration v1](../tasks/Local_Services_ACCESS_IAM_Integration_v1.md)
+11. (Optional) Technology: [Local Service ACCESS IAM Integration](../tasks/Local_Services_ACCESS_IAM_Integration_v1.md)
 
 ## Operations phase
 
-12. Support: [Incident Response and Coordination v1](../tasks/Incident_Response_and_Coordination_v1.md)
+12. Support: [Incident Response and Coordination](../tasks/Incident_Response_and_Coordination_v1.md)
 
-13. Support: [Ticket Handling v2](../tasks/Ticket_Handling_v2.md)
+13. Support: [Ticket Handling](../tasks/Ticket_Handling_v2.md)
 
-14. Support: [Operational Status Communications v1](../tasks/Operational_Status_Communications_v1.md)
+14. Support: [Operational Status Communications](../tasks/Operational_Status_Communications_v1.md)
 
-15. (Optional) Support: [Request RP or Site Staff Allocation v1](../tasks/Request_RP_or_Site_Staff_Allocation_v1.md)
+15. (Optional) Support: [Request RP or Site Staff Allocation](../tasks/Request_RP_or_Site_Staff_Allocation_v1.md)
 
-16. Technology: [AMIE and Usage Reporting v1](../tasks/AMIE_and_Usage_Reporting_v1.md)
+16. Technology: [AMIE and Usage Reporting](../tasks/AMIE_and_Usage_Reporting_v1.md)
 
-17. Technology: [Performance Data reporting v1](../tasks/Performance_Data_Reporting_v1.md)
+17. Technology: [Performance Data reporting](../tasks/Performance_Data_Reporting_v1.md)
 
 <sub>
 <ul class="document-meta-data">

--- a/docs/source/compute/ACCESS_Allocated_Production_Compute_-_Integration_Roadmap_Description.md
+++ b/docs/source/compute/ACCESS_Allocated_Production_Compute_-_Integration_Roadmap_Description.md
@@ -38,49 +38,49 @@ See related [*Roadmap Task Timeline*](https://docs.google.com/presentation/d/1Vt
 
 ## Planning phase
 
-1. Coordination: [ACCESS Allocated Resource Integration Coordination v2](../tasks/ACCESS_Allocated_Resource_Integration_Coordination_v2.md)
+1. Coordination: [ACCESS Allocated Resource Integration Coordination](../tasks/ACCESS_Allocated_Resource_Integration_Coordination_v2.md)
 
-2. Coordination: [Infrastructure Description v2](../tasks/Infrastructure_Description_v2.md)
+2. Coordination: [Infrastructure Description](../tasks/Infrastructure_Description_v2.md)
 
-3. Technology: [Cybersecurity Requirements for RPs v1](../tasks/Cybersecurity_Requirements_for_RPs_v1.md)
+3. Technology: [Cybersecurity Requirements for RPs](../tasks/Cybersecurity_Requirements_for_RPs_v1.md)
 
-4. Technology: [Data and Network Integration v1](../tasks/Data_and_Network_Integration.md)
+4. Technology: [Data and Network Integration](../tasks/Data_and_Network_Integration.md)
 
 ## Integration phase
 
-5. Coordination: [ACCESS Allocation Policies v1](../tasks/ACCESS_Allocation_Policies_v1.md)
+5. Coordination: [ACCESS Allocation Policies](../tasks/ACCESS_Allocation_Policies_v1.md)
 
-6. Coordination: [Knowledge Base v1](../tasks/Knowledge_Base_v1.md)
+6. Coordination: [Knowledge Base](../tasks/Knowledge_Base_v1.md)
 
-7. Coordination: [RP Forum Participation v1](../tasks/Resource_Provider_Forum_Participation_v1.md)
+7. Coordination: [RP Forum Participation](../tasks/Resource_Provider_Forum_Participation_v1.md)
 
-8. Coordination: [Cybersecurity Governance Council Participation v1](../tasks/Cybersecurity_Governance_Council_Participation_v1.md)
+8. Coordination: [Cybersecurity Governance Council Participation](../tasks/Cybersecurity_Governance_Council_Participation_v1.md)
 
-9. Technology: [Resource Metrics Data Availability Assessment v1](../tasks/Resource_Metrics_Data_Availability_Assessment_v1.md)
+9. Technology: [Resource Metrics Data Availability Assessment](../tasks/Resource_Metrics_Data_Availability_Assessment_v1.md)
 
-10. (Optional) Technology: [ACCESS DNS Entries v1](../tasks/ACCESS_DNS_Records_v1.md) (NEW)
+10. (Optional) Technology: [ACCESS DNS Entries](../tasks/ACCESS_DNS_Records_v1.md) (NEW)
 
-11. (Optional) Technology: [Local Service ACCESS IAM Integration v1](../tasks/Local_Services_ACCESS_IAM_Integration_v1.md)
+11. (Optional) Technology: [Local Service ACCESS IAM Integration](../tasks/Local_Services_ACCESS_IAM_Integration_v1.md)
 
-12. (Optional) Technology: [ACCESS OnDemand Portal Integration v1](../tasks/ACCESS_OnDemand_Portal_Integration_v1.md)
+12. (Optional) Technology: [ACCESS OnDemand Portal Integration](../tasks/ACCESS_OnDemand_Portal_Integration_v1.md)
 
 ## Operations phase
 
-13. Technology: [Deploy Globus Endpoint v1](../tasks/Deploy_Globus_Endpoint_v1.md)
+13. Technology: [Deploy Globus Endpoint](../tasks/Deploy_Globus_Endpoint_v1.md)
 
-14. Technology: [Publish Dynamic Resource Information v2](../tasks/Publish_Dynamic_Resource_Information_v2.md)
+14. Technology: [Publish Dynamic Resource Information](../tasks/Publish_Dynamic_Resource_Information_v2.md)
 
-15. Support: [Incident Response and Coordination v1](../tasks/Incident_Response_and_Coordination_v1.md)
+15. Support: [Incident Response and Coordination](../tasks/Incident_Response_and_Coordination_v1.md)
 
-16. Support: [Ticket Handling v2](../tasks/Ticket_Handling_v2.md)
+16. Support: [Ticket Handling](../tasks/Ticket_Handling_v2.md)
 
-17. Support: [Operational Status Communications v1](../tasks/Operational_Status_Communications_v1.md)
+17. Support: [Operational Status Communications](../tasks/Operational_Status_Communications_v1.md)
 
-18. (Optional) Support: [Request RP or Site Staff Allocation v1](../tasks/Request_RP_or_Site_Staff_Allocation_v1.md)
+18. (Optional) Support: [Request RP or Site Staff Allocation](../tasks/Request_RP_or_Site_Staff_Allocation_v1.md)
 
-19. Technology: [AMIE and Usage Reporting v1](../tasks/AMIE_and_Usage_Reporting_v1.md)
+19. Technology: [AMIE and Usage Reporting](../tasks/AMIE_and_Usage_Reporting_v1.md)
 
-20. Technology: [Performance Data reporting v1](../tasks/Performance_Data_Reporting_v1.md)
+20. Technology: [Performance Data reporting](../tasks/Performance_Data_Reporting_v1.md)
 
 <sub>
 <ul class="document-meta-data">

--- a/docs/source/gateway/ACCESS_Integrated_Science_Gateway_-_Integration_Roadmap_Description.md
+++ b/docs/source/gateway/ACCESS_Integrated_Science_Gateway_-_Integration_Roadmap_Description.md
@@ -39,7 +39,7 @@ Operators must perform the Required Tasks below and may perform the Optional Tas
 - [*Introduction to Roadmaps*](https://docs.google.com/presentation/d/1OjeT6r01mdOIa4pq1VE0L5ocRPfqdXFp9QsADjdqrjE/) slides
 
 ## Planning phase
-1. Coordination: [ACCESS Science Gateway Integration Coordination v1](../tasks/ACCESS_Science_Gateway_Integration_Coordination_v1.md)
+1. Coordination: [ACCESS Science Gateway Integration Coordination](../tasks/ACCESS_Science_Gateway_Integration_Coordination_v1.md)
 
 ## Integration/Operations phase(s)
 

--- a/docs/source/storage/ACCESS_Allocated_Production_Storage_-_Integration_Roadmap_Description.md
+++ b/docs/source/storage/ACCESS_Allocated_Production_Storage_-_Integration_Roadmap_Description.md
@@ -38,45 +38,45 @@ See related [*Roadmap Task Timeline*](https://docs.google.com/presentation/d/1YU
 
 ## Planning phase
 
-1. Coordination: [ACCESS Allocated Resource Integration Coordination v2](../tasks/ACCESS_Allocated_Resource_Integration_Coordination_v2.md)
+1. Coordination: [ACCESS Allocated Resource Integration Coordination](../tasks/ACCESS_Allocated_Resource_Integration_Coordination_v2.md)
 
-2. Coordination: [Infrastructure Description v2](../tasks/Infrastructure_Description_v2.md)
+2. Coordination: [Infrastructure Description](../tasks/Infrastructure_Description_v2.md)
 
-3. Technology: [Cybersecurity Requirements for RPs v1](../tasks/Cybersecurity_Requirements_for_RPs_v1.md)
+3. Technology: [Cybersecurity Requirements for RPs](../tasks/Cybersecurity_Requirements_for_RPs_v1.md)
 
-4. Technology: [Data and Network Integration v1](../tasks/Data_and_Network_Integration.md)
+4. Technology: [Data and Network Integration](../tasks/Data_and_Network_Integration.md)
 
 ## Integration phase
 
-5. Coordination: [ACCESS Allocation Policies v1](../tasks/ACCESS_Allocation_Policies_v1.md)
+5. Coordination: [ACCESS Allocation Policies](../tasks/ACCESS_Allocation_Policies_v1.md)
 
-6. Coordination: [Knowledge Base v1](../tasks/Knowledge_Base_v1.md)
+6. Coordination: [Knowledge Base](../tasks/Knowledge_Base_v1.md)
 
-7. Coordination: [RP Forum Participation v1](../tasks/Resource_Provider_Forum_Participation_v1.md)
+7. Coordination: [RP Forum Participation](../tasks/Resource_Provider_Forum_Participation_v1.md)
 
-8. Coordination: [Cybersecurity Governance Council Participation v1](../tasks/Cybersecurity_Governance_Council_Participation_v1.md)
+8. Coordination: [Cybersecurity Governance Council Participation](../tasks/Cybersecurity_Governance_Council_Participation_v1.md)
 
-9. Technology: [Resource Metrics Data Availability Assessment v1](../tasks/Resource_Metrics_Data_Availability_Assessment_v1.md)
+9. Technology: [Resource Metrics Data Availability Assessment](../tasks/Resource_Metrics_Data_Availability_Assessment_v1.md)
 
-10. (Optional) Technology: [ACCESS DNS Entries v1](../tasks/ACCESS_DNS_Records_v1.md)
+10. (Optional) Technology: [ACCESS DNS Entries](../tasks/ACCESS_DNS_Records_v1.md)
 
-11. (Optional) Technology: [Local Service ACCESS IAM Integration v1](../tasks/Local_Services_ACCESS_IAM_Integration_v1.md)
+11. (Optional) Technology: [Local Service ACCESS IAM Integration](../tasks/Local_Services_ACCESS_IAM_Integration_v1.md)
 
 ## Operations phase
 
-12. Technology: [Deploy Globus Endpoint v1](../tasks/Deploy_Globus_Endpoint_v1.md)
+12. Technology: [Deploy Globus Endpoint(../tasks/Deploy_Globus_Endpoint_v1.md)
 
-13. Support: [Incident Response and Coordination v1](../tasks/Incident_Response_and_Coordination_v1.md)
+13. Support: [Incident Response and Coordination](../tasks/Incident_Response_and_Coordination_v1.md)
 
-14. Support: [Ticket Handling v2](../tasks/Ticket_Handling_v2.md)
+14. Support: [Ticket Handling](../tasks/Ticket_Handling_v2.md)
 
-15. Support: [Operational Status Communications v1](../tasks/Operational_Status_Communications_v1.md)
+15. Support: [Operational Status Communications](../tasks/Operational_Status_Communications_v1.md)
 
-16. (Optional) Support: [Request RP or Site Staff Allocation v1](../tasks/Request_RP_or_Site_Staff_Allocation_v1.md)
+16. (Optional) Support: [Request RP or Site Staff Allocation](../tasks/Request_RP_or_Site_Staff_Allocation_v1.md)
 
-17. Technology: [AMIE and Usage Reporting v1](../tasks/AMIE_and_Usage_Reporting_v1.md)
+17. Technology: [AMIE and Usage Reporting](../tasks/AMIE_and_Usage_Reporting_v1.md)
 
-18. Technology: [Performance Data reporting v1](../tasks/Performance_Data_Reporting_v1.md)
+18. Technology: [Performance Data reporting](../tasks/Performance_Data_Reporting_v1.md)
 
 <sub>
 <ul class="document-meta-data">

--- a/docs/source/tasks/ACCESS_Allocated_Resource_Integration_Coordination_v2.md
+++ b/docs/source/tasks/ACCESS_Allocated_Resource_Integration_Coordination_v2.md
@@ -60,9 +60,7 @@ Soon after the Integration Launch the Resource Integration Coordinator must ente
 
 If the RP doesn’t know who some of these contacts will be, or wishes not to identify them until relevant integration effort ramps up, please name the Integration Coordinator as the placeholder for those roles. In other words, ACCESS needs each someone to be the contact in each of the above areas, even if it’s the coordinator who will eventually hand off effort to someone else. As integration activities ramps up the Integration Coordinator can add other RP staff replacing themselves as necessary.
 
-The Integration Coordinator should enter and update their RP contacts in CiDeR as detailed in the task:
-
-- [Infrastructure Description v2] (Infrastructure_Description_v2.md)
+The Integration Coordinator should enter and update their RP contacts in CiDeR as detailed in the [*Infrastructure Description task*](Infrastructure_Description_v2.md).
 
 The Integration Coordinator is responsible for maintaining accurate contact information CiDeR as RP staff change. We recommend that the Integration Coordinator review and correct their contacts every 6 months. This sub-task should take ~1 hour to complete initially, and ~½ hour annually to keep up-to-date.
 

--- a/docs/source/tasks/Publish_Dynamic_Resource_Information_v2.md
+++ b/docs/source/tasks/Publish_Dynamic_Resource_Information_v2.md
@@ -13,7 +13,7 @@ This task involves installing and running the Information Publishing Framework (
 
 ## Prerequisite tasks
 
-1.  [*Infrastructure Description v2*](Infrastructure_Description_v2.md)
+1.  [*Infrastructure Description task*](Infrastructure_Description_v2.md)
 
 ## Support Information
 

--- a/docs/source/tasks/Ticket_Handling_v2.md
+++ b/docs/source/tasks/Ticket_Handling_v2.md
@@ -13,7 +13,7 @@ ACCESS resource and online service operators will be assigned tickets for issues
 
 ## Prerequisite tasks
 
-1.  [*Infrastructure Description v2*](Infrastructure_Description_v2.md)
+1.  [*Infrastructure Description task*](Infrastructure_Description_v2.md)
 
 ## Support Information
 


### PR DESCRIPTION
The concierge team agreed to not display task version numbers in documents. See additional details in https://access-ci.atlassian.net/browse/CTT-359