### PR TITLE
remove duplicate content; operating instructions

### DIFF
--- a/docs/source/tasks/ACCESS_Allocation_Policies_v1.md
+++ b/docs/source/tasks/ACCESS_Allocation_Policies_v1.md
@@ -68,38 +68,6 @@ Some additional links that may be of benefit to RPs:
 
 Thank you for providing your essential expertise and assistance to the ACCESS ecosystem!
 
-
-## Operating Instructions
-
-RPs who are designed as Allocations Contacts, who are responsible for reviewing requests for their resources and ensuring their site's documentation is up to date, are encouraged to utilize the following tools & resources to assist with their involvement in the Allocations process. Feedback related to this document (and ACCESS Allocation Services as a whole) is welcomed through our [feedback form](https://docs.google.com/forms/d/e/1FAIpQLSdn-SXokNB_5s0r2SA_S9ZIZWZFlVPRD2OHepTH5HY2YND_zw/viewform). If you’re a new RP, please familiarize yourself with the tools and processes mentioned herein and reach out to Allocations staff for assistance.
-
-* XRAS ([eXtensible Resource Allocation Service](https://allocations.access-ci.org/about-xras))
-    * The main tool under constant development and refinement for ACCESS Allocations. The software suite provides distinct interfaces for Submit, Review, and Administration components required for end-to-end services
-* [Allocations Review Site](https://review-access.xras.org/login)
-    * Serves as the mechanism to review requests for your resource(s). We recommend that you bookmark this page!
-* [Reviewer Manual](https://docs.google.com/document/d/1s0TLyKTXrKFjjVGJxE-7nwyzHfAwX-sjjBOJbsiprf4/edit#)
-    * Documents the allocations cycle and review guidelines. We recommend that you regularly refer to this documentation as you complete any and all review assignments
-* [Reviewer Training & DEI](https://drive.google.com/drive/folders/1-ENSP1gvqGi5H2w_bKjwr6ocvVJaT-kw)
-    * In order to create an open, inviting, and democratized allocations marketplace various training and reference materials are provided
-* [Allocations Queries](https://xacct-admin.access-ci.org/allocations_queries)
-    * Provides overviews of a user’s or a project’s history of actions
-    * To request access to this tool, please [create a ticket](https://support.access-ci.org/open-a-ticket)
-* [Available Allocation Opportunities](https://allocations.access-ci.org/prepare-requests-overview)
-    * Details the four opportunities to request allocations on ACCESS resources
-* [ACCESS Credits](https://allocations.access-ci.org/use-credits-overview)
-    * Allocations for the first three opportunity levels are awarded in ACCESS Credits
-    * A credit exchange rate must be established by the Resource Provider for the systems they will allocate. This is done through the [CyberInfrastructure Description Repository (CiDeR)](https://cider.access-ci.org/login)
-    * RPs can contact Allocations if they have questions on setting their exchange rate
-    * **Tip for storage resource providers:** At this time, most ACCESS storage resources
-      have set an exchange rate of one ACCESS credit to one resource unit. Additionally,
-      most storage resources have a rate of one resource unit to 1 GB (gigabyte)
-      of storage. Keeping these consistent, if possible, will help reduce confusion
-      (and avoid support tickets). If you intend to set different rates for your resource,
-      please review the implications with a representative from the ACCESS Allocations team.
-* [Resource Catalog](https://allocations.access-ci.org/resources)
-    * Summarizes all resources currently available in the ACCESS ecosystem
-    * The RP Allocation contact is responsible for contributing and reviewing the descriptions and associated content for each allocated resource (also through CiDeR)
-
 ## Contact Information
 
 The ACCESS Allocations staff can be contacted through the following mechanisms:


### PR DESCRIPTION
[ACCESS_Allocation_Policies_v1.md](https://github.com/access-ci-org/Integration_Roadmaps/blob/main/docs/source/tasks/ACCESS_Allocation_Policies_v1.md) currently has duplicate content for Detailed Instructions and Operating Instructions. This PR removes the Operating Instructions section in favor of Detailed Instructions which I chose purely because recent PRs (https://github.com/access-ci-org/Integration_Roadmaps/pull/92 and https://github.com/access-ci-org/Integration_Roadmaps/pull/93) had content updates only within Detailed Instructions.

The current [ACCESS_Allocation_Policies_v1.md](https://github.com/access-ci-org/Integration_Roadmaps/blob/main/docs/source/tasks/ACCESS_Allocation_Policies_v1.md) Task Expert (Ken Hackworth) would be the recommended reviewer for this PR, but I'm unable to find their username. I will leave the reviewer empty at this time.

Ticket: https://access-ci.atlassian.net/browse/CTT-552