### PR TITLE
update task experts for ACCESS DNS Records

### DIFF
--- a/docs/source/tasks/ACCESS_DNS_Records_v1.md
+++ b/docs/source/tasks/ACCESS_DNS_Records_v1.md
@@ -27,7 +27,7 @@ ACCESS projects, integrated resources, and central service operators may request
 <ul class="document-meta-data">
     <li><strong>Status</strong>: Production</li>
     <li><strong>Version</strong>: v1</li>
-    <li><strong>Task Expert(s)</strong>: Kathy Benninger and Matthew Kollross, ACCESS Operations</li>
+    <li><strong>Task Expert(s)</strong>: Matthew Kollross and Blade Pickering, ACCESS Operations</li>
 </ul>
 </sub>
 <br/>


### PR DESCRIPTION
I've confirmed with Matt Kollross over ACCESS slack DM that this should be the current list of task experts for [ACCESS DNS Records](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/ACCESS_DNS_Records_v1.html).