### PR TITLE
update task experts for Data and Network Integration + CONECTnet Integration tasks

### DIFF
--- a/docs/source/tasks/CONECTnet_Integration_v1.md
+++ b/docs/source/tasks/CONECTnet_Integration_v1.md
@@ -43,7 +43,7 @@ Is this tied to CONECTnet Integration?
 <ul class="document-meta-data">
     <li><strong>Status</strong>: Production</li>
     <li><strong>Version</strong>: v1</li>
-    <li><strong>Task Expert(s)</strong>: Kathy Benninger and David Wheeler, ACCESS Operations</li>
+    <li><strong>Task Expert(s)</strong>: Dave Wheeler, ACCESS Operations</li>
 </ul>
 </sub>
 <br/>

--- a/docs/source/tasks/Data_and_Network_Integration.md
+++ b/docs/source/tasks/Data_and_Network_Integration.md
@@ -95,7 +95,7 @@ Globus requires specific system, application, and (potentially) hardware configu
 <ul class="document-meta-data">
     <li><strong>Status</strong> : Production</li>
     <li><strong>Version</strong> : v1</li>
-    <li><strong>Task Expert(s)</strong> : Kathy Benninger, ACCESS Operations</li>
+    <li><strong>Task Expert(s)</strong>: Dave Wheeler, ACCESS Operations</li>
 </ul>
 </sub>
 <br/>


### PR DESCRIPTION
I've confirmed with Dave Wheeler over ACCESS slack DM that this should be the current list of task experts for [Data and Network Integration](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/Data_and_Network_Integration.html) and [CONECTnet Integration](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/CONECTnet_Integration_v1.html).

NOTE: [CONECTnet Integration](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/CONECTnet_Integration_v1.html) is currently not referenced in any Integration Roadmaps, but is defined in the new ACCESS Enhanced Networking badge