### PR TITLE
Update task expert names from Rob Quick to Chun Chan

### DIFF
--- a/docs/source/tasks/Request_Science_Gateway_Community_Accounts_v1.md
+++ b/docs/source/tasks/Request_Science_Gateway_Community_Accounts_v1.md
@@ -48,7 +48,7 @@ accessing the resource provider.
 <ul class="document-meta-data">
     <li><strong>Status</strong> : Production</li>
     <li><strong>Version</strong> : v1</li>
-    <li><strong>Task Expert(s)</strong> : Dinuka De Silva, Rob Quick</li>
+    <li><strong>Task Expert(s)</strong> : Chun Chan, Dinuka De Silva</li>
 </ul>
 </sub>
 <br/>

--- a/docs/source/tasks/Science_Gateway_Usage_Reporting_v1.md
+++ b/docs/source/tasks/Science_Gateway_Usage_Reporting_v1.md
@@ -34,7 +34,7 @@ After integration, the gateway provider should verify that usage is being correc
 <ul class="document-meta-data">
     <li><strong>Status</strong> : Production</li>
     <li><strong>Version</strong> : v1</li>
-    <li><strong>Task Expert(s)</strong> : Dinuka De Silva, Rob Quick</li>
+    <li><strong>Task Expert(s)</strong> : Chun Chan, Dinuka De Silva</li>
 </ul>
 </sub>
 <br/>


### PR DESCRIPTION
Changed task expert names for the _Science Gateway Community Accounts_ and _Science Gateway Usage Reporting_ docs from Rob Quick to Chun Chan.