### PR TITLE
Update support information link in Science Gateway Description doc

### DIFF
--- a/docs/source/tasks/Science_Gateway_Description_v1.md
+++ b/docs/source/tasks/Science_Gateway_Description_v1.md
@@ -18,7 +18,7 @@ accessible information about the science gateway.
 
 ## Support Information
 
-For assistance with this task see the **Support Information** section in the [Infrastructure Integration Roadmap Description](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/gateway/ACCESS_Integrated_Science_Gateway_-_Integration_Roadmap_Description.html#support-information).
+For assistance with this task see the **Support Information** section in the [Infrastructure Integration Roadmap Description](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/Infrastructure_Description_v3.html#support-information).
 
 ## Detailed Instructions
 

--- a/docs/source/tasks/Science_Gateway_Description_v1.md
+++ b/docs/source/tasks/Science_Gateway_Description_v1.md
@@ -18,7 +18,8 @@ accessible information about the science gateway.
 
 ## Support Information
 
-For assistance with this task see the **Support Information** section in the [Infrastructure Integration Roadmap Description](https://readthedocs.access-ci.org/projects/integration-roadmaps/en/latest/tasks/Infrastructure_Description_v3.html#support-information).
+```{include} ../support.md
+```
 
 ## Detailed Instructions
 


### PR DESCRIPTION
Resolved a broken link under the "Support Information" section by updating it to point to the appropriate section within the Infrastructure Integration Roadmap description.