### PR TITLE
remove whitespace from markdown link syntax

### DIFF
--- a/docs/source/tasks/ACCESS_Allocated_Resource_Integration_Coordination_v2.md
+++ b/docs/source/tasks/ACCESS_Allocated_Resource_Integration_Coordination_v2.md
@@ -62,7 +62,7 @@ If the RP doesn’t know who some of these contacts will be, or wishes not to id
 
 The Integration Coordinator should enter and update their RP contacts in CiDeR as detailed in the task:
 
-- [Infrastructure Description v2] (Infrastructure_Description_v2.md)
+- [Infrastructure Description v2](Infrastructure_Description_v2.md)
 
 The Integration Coordinator is responsible for maintaining accurate contact information CiDeR as RP staff change. We recommend that the Integration Coordinator review and correct their contacts every 6 months. This sub-task should take ~1 hour to complete initially, and ~½ hour annually to keep up-to-date.
 


### PR DESCRIPTION
Fix broken markdown link caused by whitespace.