### PR TITLE
Align Science Gateway Description task instructions with ACCESS ticketing form

### DIFF
--- a/docs/source/tasks/Science_Gateway_Description_v1.md
+++ b/docs/source/tasks/Science_Gateway_Description_v1.md
@@ -23,7 +23,7 @@ None
 
 ## Detailed Instructions
 
-The science gateway provider must create an [Integration and Operations Request](https://operations.access-ci.org/open-operations-request)
+The science gateway provider must create an [Integration and Operations Request](https://operations.access-ci.org/open-new-integration-request)
  - Provide an appropriate title
  - Set *ACCESS Operational Support Issues* to ACCESS-wide: *Resource Integration*
  - Include all the details of the gateway in the description. Please use the following template.

--- a/docs/source/tasks/Science_Gateway_Description_v1.md
+++ b/docs/source/tasks/Science_Gateway_Description_v1.md
@@ -25,8 +25,7 @@ accessible information about the science gateway.
 
 The science gateway provider must create an [Integration and Operations Request](https://operations.access-ci.org/open-operations-request)
  - Provide an appropriate title
- - Set *ACCESS Operational Support Issues* to ACCESS-wide: Provider Integration - Infrastructure Integration and Roadmaps 
- - Set *Infrastructure Type:* Science Gateway and specify the *Science gateway name*
+ - Set *ACCESS Operational Support Issues* to ACCESS-wide: *Resource Integration*
  - Include all the details of the gateway in the description. Please use the following template.
 
 ```md
@@ -62,6 +61,8 @@ Integration coordinator:
 *Integration coordinator* is the contact person from the science gateway side working with the ACCESS concierge on the 
 integration process. 
 
+ - Under Infrastructure Information -> Infrastructure Type, select *ACCESS Science Gateway* and specify the *science gateway name*
+
 Once the ticket is created, it will be reviewed by the ACCESS concierge and will get back to you for additional 
 information. And then the ACCESS concierge would create/update the information in the ACCESS website. The task is completed 
 when the gateway information is published to the ACCESS website.
@@ -74,7 +75,7 @@ subsequent tickets in the future to update the information.
 <ul class="document-meta-data">
     <li><strong>Status</strong> : Production</li>
     <li><strong>Version</strong> : v1</li>
-    <li><strong>Task Expert(s)</strong> : Dinuka De Silva, Rob Quick</li>
+    <li><strong>Task Expert(s)</strong> : Chun Chan, Dinuka De Silva</li>
 </ul>
 </sub>
 <br/>

--- a/docs/source/tasks/Science_Gateway_Description_v1.md
+++ b/docs/source/tasks/Science_Gateway_Description_v1.md
@@ -14,7 +14,7 @@ accessible information about the science gateway.
 
 ## Prerequisite tasks
 
-1.  The science gateway provider must have completed [Request Science Gateway Resources](Request_Science_Gateway_Resources_v1.md)
+None
 
 ## Support Information
 

--- a/docs/source/tasks/Science_Gateway_Description_v1.md
+++ b/docs/source/tasks/Science_Gateway_Description_v1.md
@@ -24,20 +24,24 @@ None
 ## Detailed Instructions
 
 The science gateway provider must create an [Integration and Operations Request](https://operations.access-ci.org/open-new-integration-request)
- - Provide an appropriate title
- - Set *ACCESS Operational Support Issues* to ACCESS-wide: *Resource Integration*
- - Include all the details of the gateway in the description. Please use the following template.
+ - Under *Organization Name* enter the name of the supporting institution.
+ - Under *Resource Name* enter the name of the science gateway.
+ - For *Infrastructure Type* select *Science Gateways*.
+ - Under *Resource Website URL* enter the URL of the science gateway.
+ - Provide your resource integration coordinator's name, email address and ACCESS ID (if available).
+ ```{note}
+*Integration coordinator* is the contact person from the science gateway side working with the ACCESS concierge on the integration process. 
+```
+ - Select the options that best describe the funding program and scope of the science gateway.
+ - Include the following details of the gateway in the *Additional Details* text entry box. Please use the following template:
 
 ```md
-Institution Name: 
 Science Gateway Name: 
 Acronym: 
-Public URL: 
-Short Name: 
 Short Description: 
 Associated allocation ID(s): 
 Status (in development or in production): 
-Production date (when did/will it become): 
+Production date (when did/will it become production): 
 
 Gateway PI: 
     First name, Last name <email>
@@ -53,22 +57,14 @@ Gateway administrator(s):
 Cybersecurity and incident response contact(s):
     First name, Last name <email>
     First name, Last name <email>
-    
-Integration coordinator: 
-    First name, Last name <email>
 ```
 
-*Integration coordinator* is the contact person from the science gateway side working with the ACCESS concierge on the 
-integration process. 
-
- - Under Infrastructure Information -> Infrastructure Type, select *ACCESS Science Gateway* and specify the *science gateway name*
-
-Once the ticket is created, it will be reviewed by the ACCESS concierge and will get back to you for additional 
-information. And then the ACCESS concierge would create/update the information in the ACCESS website. The task is completed 
+Once the ticket is created, the ACCESS concierge will review it and get back to you if additional information is 
+needed. The ACCESS concierge will then create/update the information on the ACCESS website. The task is completed 
 when the gateway information is published to the ACCESS website.
 
 ACCESS may periodically review registration information to confirm that it is correct. Gateway providers should create 
-subsequent tickets in the future to update the information.
+subsequent tickets to update the information.
 
 
 <sub>


### PR DESCRIPTION
# Summary
Several steps in the Science Gateway Description task instructions require users to submit a form through the [ACCESS ticket](https://operations.access-ci.org/open-operations-request) system. Several menu options available on the ticket form did not align with the detailed instructions provided for the Science Gateway Description task. This PR updates the task instructions to reflect the current ticket form and resolves those inconsistencies.

**Update (2026-07-19):** After this PR was opened, a newer form for resource integration discovered [here](https://operations.access-ci.org/open-new-integration-request) which contains a slightly different set of form fields. A later commit revises some of the field mappings from the original commit above (see that commit's message for details) — the "Changes" list below reflects the final state, not each intermediate commit.

# Changes
- Modified the bullet points under "Detailed Instructions" to match the sequence of fields in the new operations request [ACCESS ticket form](https://operations.access-ci.org/open-new-integration-request).
- Modified the "Additional Details" template to include only necessary fields that do not duplicate data already captured in the new operations request [ACCESS ticket form](https://operations.access-ci.org/open-new-integration-request).
- Removed prerequisite tasks

# Notes
- Changes here are relatively minor, so I don't think this needs to be split out into a separate "v2" version.